### PR TITLE
remove isdefined __precompile__

### DIFF
--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -1,4 +1,4 @@
-isdefined(Base, :__precompile__) && __precompile__()
+__precompile__()
 
 module CxxWrap
 


### PR DESCRIPTION
Not needed since 0.4 and above support __precompile__