### PR TITLE
lower Compat requirement to 0.18

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.5
 BinDeps 0.4.2
-Compat 0.21
+Compat 0.18


### PR DESCRIPTION
only need parametric type aliases, not anything newer at the moment
ref https://github.com/JuliaLang/METADATA.jl/pull/8818#discussion_r111274943