### PR TITLE
Use at-compat for IndexStyle

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.5
 BinDeps 0.4.2
-Compat 0.18
+Compat 0.19

--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -116,11 +116,7 @@ function __init__()
     Libdl.dlopen(cxx_wrap_path, Libdl.RTLD_GLOBAL)
   end
   ccall((:initialize, cxx_wrap_path), Void, (Any, Any, Any), CxxWrap, CppAny, CppFunctionInfo)
-  @static if VERSION < v"0.6-dev"
-    Base.linearindexing(::ConstArray) = Base.LinearFast()
-  else
-    Base.IndexStyle(::ConstArray) = Base.IndexLinear()
-  end
+  @compat Base.IndexStyle(::ConstArray) = IndexLinear()
   Base.size(arr::ConstArray) = arr.size
   Base.getindex(arr::ConstArray, i::Integer) = unsafe_load(arr.ptr.ptr, i)
 end


### PR DESCRIPTION
from Compat 0.19 - otherwise the package will be broken on early 0.6-dev versions
from before this renaming

hadn't noticed this in the diff yet