### PR TITLE
DataType -> Type

### DIFF
--- a/deps/src/cxx_wrap/include/cxx_wrap/type_conversion.hpp
+++ b/deps/src/cxx_wrap/include/cxx_wrap/type_conversion.hpp
@@ -697,7 +697,7 @@ template<> struct static_type_mapping<void*>
 template<> struct static_type_mapping<jl_datatype_t*>
 {
   typedef jl_datatype_t* type; // Debatable if this should be jl_value_t*
-  static jl_datatype_t* julia_type() { return jl_datatype_type; }
+  static jl_datatype_t* julia_type() { return jl_any_type; }
 };
 
 template<> struct static_type_mapping<jl_value_t*>


### PR DESCRIPTION
Fixex https://github.com/QuantStack/xtensor-julia/pull/46 with respect to non fully specialized parametric types not being data type anymore with Julia 0.6, but unionall instead.

cf. https://discourse.julialang.org/t/what-is-a-unionall-type/721/3