### PR TITLE
Use std::complex instead of JuliaComplex

### DIFF
--- a/deps/src/jlcxx/include/jlcxx/jlcxx.hpp
+++ b/deps/src/jlcxx/include/jlcxx/jlcxx.hpp
@@ -26,7 +26,9 @@ namespace detail
 template<typename R, typename... Args>
 struct ReturnTypeAdapter
 {
-  inline mapped_return_type<R> operator()(const void* functor, mapped_julia_type<Args>... args)
+  using return_type = decltype(convert_to_julia(std::declval<R>()));
+
+  inline return_type operator()(const void* functor, mapped_julia_type<Args>... args)
   {
     auto std_func = reinterpret_cast<const std::function<R(Args...)>*>(functor);
     assert(std_func != nullptr);
@@ -49,7 +51,9 @@ struct ReturnTypeAdapter<void, Args...>
 template<typename R, typename... Args>
 struct CallFunctor
 {
-  static mapped_return_type<R> apply(const void* functor, mapped_julia_type<Args>... args)
+  using return_type = decltype(ReturnTypeAdapter<R, Args...>()(std::declval<const void*>(), std::declval<mapped_julia_type<Args>>()...));
+
+  static return_type apply(const void* functor, mapped_julia_type<Args>... args)
   {
     try
     {
@@ -60,7 +64,7 @@ struct CallFunctor
       jl_error(err.what());
     }
 
-    return mapped_return_type<R>();
+    return return_type();
   }
 };
 

--- a/deps/src/jlcxx/include/jlcxx/type_conversion.hpp
+++ b/deps/src/jlcxx/include/jlcxx/type_conversion.hpp
@@ -1417,25 +1417,13 @@ template<typename T> struct static_type_mapping<T&, typename std::enable_if<IsFu
   static jl_datatype_t* julia_type() { return (jl_datatype_t*)apply_type((jl_value_t*)::jlcxx::julia_type("Ref"), jl_svec1(static_type_mapping<T>::julia_type())); }
 };
 
-namespace detail
-{
-
-template<typename T>
-struct JuliaComplex
-{
-  T a;
-  T b;
-};
-
-}
-
 // Complex numbers
 template<typename NumberT> struct IsBits<std::complex<NumberT>> : std::true_type {};
 template<typename NumberT> struct IsImmutable<std::complex<NumberT>> : std::true_type {};
 
 template<typename NumberT> struct static_type_mapping<std::complex<NumberT>>
 {
-  typedef detail::JuliaComplex<NumberT> type;
+  typedef std::complex<NumberT> type;
   static jl_datatype_t* julia_type()
   {
     static jl_datatype_t* dt = nullptr;
@@ -1451,18 +1439,18 @@ template<typename NumberT> struct static_type_mapping<std::complex<NumberT>>
 template<typename NumberT>
 struct ConvertToCpp<std::complex<NumberT>, false, true, true>
 {
-  std::complex<NumberT> operator()(detail::JuliaComplex<NumberT> julia_value) const
+  std::complex<NumberT> operator()(std::complex<NumberT> julia_value) const
   {
-    return std::complex<NumberT>(julia_value.a, julia_value.b);
+    return julia_value;
   }
 };
 
 template<typename NumberT>
 struct ConvertToJulia<std::complex<NumberT>, false, true, true>
 {
-  detail::JuliaComplex<NumberT> operator()(const std::complex<NumberT> cpp_val) const
+  std::complex<NumberT> operator()(std::complex<NumberT> cpp_value) const
   {
-    return {cpp_val.real(), cpp_val.imag()};
+    return cpp_value;
   }
 };
 


### PR DESCRIPTION
1) This PR replaces `detail:: JuliaComplex<T>` with `std::complex<T>`.

The only requirement for the `type` typedef in `static_type_mapping` is that it has the same size and provides a meaningful way to use the content, and `std::complex` does that as well as `template <class T> struct { T a; T b; };`.

2) The benefit is in the downstream project `Xtensor.jl` for the handling of arrays of complex numbers.

The jlarray / jltensor are based on a structure called `xbuffer_adaptor` which is a wrapper on a raw buffer providing a `std::vector`-style API, and the wrapping xtensor expression inherit its typedefs from it - and the `xbuffer_adaptor` type is `xbuffer_adaptor<jlcxx::mapped_julia_type<T>>;`... Making this change enables `operator()` to return references on complex numbers in xtensor-julia.