### PR TITLE
Allow failure on nighlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,7 @@ matrix:
     - os: osx
       compiler: "clang"
       julia: nightly
+  allow_failures:
+      julia: nightly
 notifications:
   email: true


### PR DESCRIPTION
Allow the test with the Julia nightly build to fail. (Although we would still have the information).