### PR TITLE
Adding quotes around variables to string commands

### DIFF
--- a/deps/src/jlcxx/FindJulia.cmake
+++ b/deps/src/jlcxx/FindJulia.cmake
@@ -21,7 +21,7 @@ execute_process(
 
 string(
     REGEX REPLACE ".*([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1"
-      Julia_VERSION_STRING ${Julia_VERSION_STRING}
+      Julia_VERSION_STRING "${Julia_VERSION_STRING}"
 )
 
 MESSAGE(STATUS "Julia_VERSION_STRING: ${Julia_VERSION_STRING}")
@@ -46,8 +46,8 @@ else()
         OUTPUT_VARIABLE Julia_INCLUDE_DIRS
     )
 
-    string(REGEX REPLACE "\"" "" Julia_INCLUDE_DIRS ${Julia_INCLUDE_DIRS})
-    string(REGEX REPLACE "\n" "" Julia_INCLUDE_DIRS ${Julia_INCLUDE_DIRS})
+    string(REGEX REPLACE "\"" "" Julia_INCLUDE_DIRS "${Julia_INCLUDE_DIRS}")
+    string(REGEX REPLACE "\n" "" Julia_INCLUDE_DIRS "${Julia_INCLUDE_DIRS}")
     set(Julia_INCLUDE_DIRS ${Julia_INCLUDE_DIRS}
         CACHE PATH "Location of Julia include files")
 endif()
@@ -62,8 +62,8 @@ execute_process(
     OUTPUT_VARIABLE Julia_LIBRARY_DIR
 )
 
-string(REGEX REPLACE "\"" "" Julia_LIBRARY_DIR ${Julia_LIBRARY_DIR})
-string(REGEX REPLACE "\n" "" Julia_LIBRARY_DIR ${Julia_LIBRARY_DIR})
+string(REGEX REPLACE "\"" "" Julia_LIBRARY_DIR "${Julia_LIBRARY_DIR}")
+string(REGEX REPLACE "\n" "" Julia_LIBRARY_DIR "${Julia_LIBRARY_DIR}")
 
 string(STRIP ${Julia_LIBRARY_DIR} Julia_LIBRARY_DIR)
 set(Julia_LIBRARY_DIR ${Julia_LIBRARY_DIR}
@@ -96,8 +96,8 @@ execute_process(
     OUTPUT_VARIABLE JULIA_HOME
 )
 
-string(REGEX REPLACE "\"" "" JULIA_HOME ${JULIA_HOME})
-string(REGEX REPLACE "\n" "" JULIA_HOME ${JULIA_HOME})
+string(REGEX REPLACE "\"" "" JULIA_HOME "${JULIA_HOME}")
+string(REGEX REPLACE "\n" "" JULIA_HOME "${JULIA_HOME}")
 
 MESSAGE(STATUS "JULIA_HOME:           ${JULIA_HOME}")
 
@@ -110,8 +110,8 @@ execute_process(
     OUTPUT_VARIABLE Julia_LLVM_VERSION
 )
 
-string(REGEX REPLACE "\"" "" Julia_LLVM_VERSION ${Julia_LLVM_VERSION})
-string(REGEX REPLACE "\n" "" Julia_LLVM_VERSION ${Julia_LLVM_VERSION})
+string(REGEX REPLACE "\"" "" Julia_LLVM_VERSION "${Julia_LLVM_VERSION}")
+string(REGEX REPLACE "\n" "" Julia_LLVM_VERSION "${Julia_LLVM_VERSION}")
 
 ##################################
 # Check for Existence of Headers #

--- a/deps/src/jlcxx/FindJulia.cmake
+++ b/deps/src/jlcxx/FindJulia.cmake
@@ -15,7 +15,7 @@ MESSAGE(STATUS "Julia_EXECUTABLE:     ${Julia_EXECUTABLE}")
 #################
 
 execute_process(
-    COMMAND ${Julia_EXECUTABLE} --startup-file=no --version
+    COMMAND "${Julia_EXECUTABLE}" --startup-file=no --version
     OUTPUT_VARIABLE Julia_VERSION_STRING
 )
 
@@ -65,8 +65,8 @@ execute_process(
 string(REGEX REPLACE "\"" "" Julia_LIBRARY_DIR "${Julia_LIBRARY_DIR}")
 string(REGEX REPLACE "\n" "" Julia_LIBRARY_DIR "${Julia_LIBRARY_DIR}")
 
-string(STRIP ${Julia_LIBRARY_DIR} Julia_LIBRARY_DIR)
-set(Julia_LIBRARY_DIR ${Julia_LIBRARY_DIR}
+string(STRIP "${Julia_LIBRARY_DIR}" Julia_LIBRARY_DIR)
+set(Julia_LIBRARY_DIR "${Julia_LIBRARY_DIR}"
     CACHE PATH "Julia library directory")
 
 if(WIN32)


### PR DESCRIPTION
I've been getting errors of the type
```
CMake Error at /home/jstrube/.julia/v0.6/CxxWrap/deps/usr/share/cmake/JlCxx/FindJulia.cmake:22 (string):
  string sub-command REGEX, mode REPLACE needs at least 6 arguments total to
  command.
Call Stack (most recent call first):
  /home/jstrube/.julia/v0.6/CxxWrap/deps/usr/share/cmake/JlCxx/JlCxxConfig.cmake:2 (find_package)
  CMakeLists.txt:13 (find_package)
```
This commit fixes them.