### PR TITLE
Project config install directory

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -82,7 +82,7 @@ for l in lib_labels
 end
 
 cxx_steps = @build_steps begin
-  `cmake -G "$genopt" -DCMAKE_INSTALL_PREFIX="$prefix" -DCMAKE_BUILD_TYPE="$build_type" -DCMAKE_PROGRAM_PATH=$JULIA_HOME -DJLCXX_BUILD_EXAMPLES=$build_examples $jlcxx_srcdir`
+  `cmake -G "$genopt" -DCMAKE_INSTALL_PREFIX="$prefix" -DCMAKE_BUILD_TYPE="$build_type" -DCMAKE_PROGRAM_PATH=$JULIA_HOME -DJLCXX_BUILD_EXAMPLES=$build_examples -DCMAKE_INSTALL_LIBDIR=lib $jlcxx_srcdir`
   `cmake --build . --config $build_type --target install $makeopts`
 end
 

--- a/deps/src/jlcxx/CMakeLists.txt
+++ b/deps/src/jlcxx/CMakeLists.txt
@@ -127,8 +127,8 @@ endif()
 # Installation
 # ============
 
-# GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
-set(JLCXX_CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}" CACHE STRING "install path for jlcxxConfig.cmake")
+set(JLCXX_CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" CACHE STRING "install path for jlcxxConfig.cmake")
+
 
 install(TARGETS ${JLCXX_TARGET} EXPORT JlCxxTargets
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
This changes where the `jlcxxConfig.cmake` gets installed.

The reasons for this are detailed by @ghisvail (Debian package maintainer) in https://github.com/QuantStack/xtensor/pull/349, and we have been updating all the projects since. CxxWrap is one of the upstream project where I used the same pattern for the installation of projectConfig.cmake. 