### PR TITLE
[WIP]: Init cxxwrap in `@wrapmodule` to fix static compilation

### DIFF
--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -384,6 +384,10 @@ function readmodule(so_path::AbstractString, funcname, m::Module)
 end
 
 function wrapmodule(so_path::AbstractString, funcname, m::Module)
+  # Initialize the jlcxxwrap library from top-level user code, so that it will still
+  # be initialized for static compilation. (See:
+  #   https://github.com/JuliaInterop/libcxxwrap-julia/issues/24)
+  ccall((:initialize, jlcxx_path), Cvoid, (Any, Any), CxxWrap, CppFunctionInfo)
   readmodule(so_path, funcname, m)
   wraptypes(m)
   wrapfunctions(m)


### PR DESCRIPTION
This is a super-simple fix for https://github.com/JuliaInterop/libcxxwrap-julia/issues/24.

I'm not sure if it's the _best_ approach, but it seems sensible to me: nothing should be incorrectly baked in at compiletime and it will be reinitialized at runtime for any runtime-only calls to CxxWrap.

I am opening this PR to see if all the tests still pass, because I wasn't able to figure out how to run the tests locally. :)