### PR TITLE
Add .toml files to register a version for the new Pkg3 Registry

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,71 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BinaryProvider]]
+deps = ["Libdl", "Pkg", "SHA", "Test"]
+git-tree-sha1 = "055eb2690182ebc31087859c3dd8598371d3ef9e"
+uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+version = "0.5.3"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -2,3 +2,9 @@ name = "CxxWrap"
 uuid = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 authors = ["Bart Janssens <bart@bartjanssens.org>"]
 version = "0.8.2"
+
+[deps]
+BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+
+[compat]
+BinaryProvider = "0.5"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,14 @@ version = "0.8.2"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
 BinaryProvider = "0.5"
 julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -8,3 +8,4 @@ BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 
 [compat]
 BinaryProvider = "0.5"
+julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,4 @@
+name = "CxxWrap"
+uuid = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
+authors = ["Bart Janssens <bart@bartjanssens.org>"]
+version = "0.8.2"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 1.0
-BinaryProvider 0.5 0.6


### PR DESCRIPTION
I saw you mention in this commit that the release isn't in the registry yet: https://github.com/JuliaInterop/CxxWrap.jl/pull/136#issuecomment-485110840

In fact, the old "Attobot" way of registering packages has been turned off! See this thread for more information:
https://discourse.julialang.org/t/switching-package-registration-systems-soon/22677/132

------

This PR adds .toml files to this repo so that you can check it in via Registrator.jl! 😄 

I got the `uuid` by checking the General registry here:
https://github.com/JuliaRegistries/General/blob/master/C/CxxWrap/Package.toml

You only actually need the `Project.toml`, but Stefan recommends checking in a Manifest so that people can see an example of a working environment that satisfied the compat requirements and passed the build. Up to you though, i can also delete it if you'd like.

I also deleted the `REQUIRE` file since it's no longer needed! :)

--------

When this PR is merged, we can open an Issue and ask Registrator to register it, and it should all work correctly! :)