### PR TITLE
Fix Static Compilation: Move BinaryProvider out of src/, since only used in test/

### DIFF
--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -1,6 +1,5 @@
 module CxxWrap
 
-import BinaryProvider
 import Libdl
 
 export @wrapmodule, @readmodule, @wraptypes, @wrapfunctions, @safe_cfunction, @initcxx, load_module, ptrunion, CppEnum, ConstPtr, ConstArray, gcprotect, gcunprotect, isnull, nullptr
@@ -24,8 +23,6 @@ if !isfile(depsfile)
 end
 include(depsfile)
 const jlcxx_path = libcxxwrap_julia
-
-prefix() =  BinaryProvider.Prefix(dirname(dirname(jlcxx_path)))
 
 # Trait type to indicate a type is a C++-wrapped type
 struct IsCxxType end

--- a/test/build.jl
+++ b/test/build.jl
@@ -1,7 +1,7 @@
 using BinaryProvider
 using CxxWrap
 
-prefix() =  BinaryProvider.Prefix(dirname(dirname(jlcxx_path)))
+prefix() =  BinaryProvider.Prefix(dirname(dirname(CxxWrap.jlcxx_path)))
 
 products = Product[]
 for basename in ["jlcxx_containers", "except", "extended", "functions", "hello", "inheritance", "parametric", "pointer_modification", "types"]

--- a/test/build.jl
+++ b/test/build.jl
@@ -1,10 +1,12 @@
 using BinaryProvider
 using CxxWrap
 
+prefix() =  BinaryProvider.Prefix(dirname(dirname(jlcxx_path)))
+
 products = Product[]
 for basename in ["jlcxx_containers", "except", "extended", "functions", "hello", "inheritance", "parametric", "pointer_modification", "types"]
   fullname = "lib"*basename
-  push!(products, LibraryProduct(CxxWrap.prefix(), fullname, Symbol(fullname)))
+  push!(products, LibraryProduct(prefix(), fullname, Symbol(fullname)))
 end
 
 if any(!satisfied(p; verbose=true) for p in products)


### PR DESCRIPTION
BinaryProvider is not meant to be loaded at runtime. It does lots of
things that aren't acceptable at runtime, which is why it goes through
the care of generating a `deps.jl` file that doesn't import it.

This commit takes BinaryProvider out of `src/CxxWrap.jl` so that code
using CxxWrap doesn't wind up with BinaryProvider in its runtime
dependencies.

Since it's only used in that one test/build.jl file anyway, this is fine.