### PR TITLE
add equality for ref to string

### DIFF
--- a/src/StdLib.jl
+++ b/src/StdLib.jl
@@ -37,6 +37,8 @@ function Base.iterate(s::CppBasicString, i::Integer=1)
   return(convert(Char,codeunit(s,i)),i+1)
 end
 
+Base.:(==)(x::CxxWrap.ConstCxxRef{CxxWrap.StdLib.StdString}, y) = x[] == y
+
 function StdWString(s::String)
   char_arr = transcode(Cwchar_t, s)
   StdWString(char_arr, length(char_arr))


### PR DESCRIPTION
The API I'm wrapping has methods that return strings. I don't think I'll need assignment on those, but testing for equality with a julia string, so I've overloaded the operator in my package. Is this useful here, or should it be more generic before adding to CxxWrap?