### PR TITLE
Improve prefix_path tests

### DIFF
--- a/test/functions.jl
+++ b/test/functions.jl
@@ -57,7 +57,8 @@ end
 
 @testset "$(basename(@__FILE__)[1:end-3])" begin
 
-@test CxxWrap.prefix_path() == dirname(dirname(CxxWrap.CxxWrapCore.libcxxwrap_julia_jll.libcxxwrap_julia_path))
+@test isdir(CxxWrap.prefix_path())
+@test isfile(joinpath(CxxWrap.prefix_path(), "lib", "cmake", "JlCxx", "FindJulia.cmake"))
 
 # Test functions from the CppHalfFunctions module
 @test CppHalfFunctions.half_d(3) == 1.5


### PR DESCRIPTION
Explicitly test whether the returned path refers to a valid directory,
and contains the cmake files package rely on.

This is IMHO better than just comparing it to the value it is defined to be,
as this won't catch all kinds of errors; for example if it ever happened that
CxxWrap.CxxWrapCore.libcxxwrap_julia_jll.libcxxwrap_julia_path returns a bogus
value, the old test would still pass