### PR TITLE
Export CxxWrap.prefix_path

### DIFF
--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -786,7 +786,7 @@ end
 include("StdLib.jl")
 
 using .CxxWrapCore
-using .CxxWrapCore: CxxBaseRef, jlcxx_path, argument_overloads, SafeCFunction, reference_type_union, dereference_argument, @cxxdereference
+using .CxxWrapCore: CxxBaseRef, jlcxx_path, argument_overloads, SafeCFunction, reference_type_union, dereference_argument, @cxxdereference, prefix_path
 
 export @wrapmodule, @readmodule, @wraptypes, @wrapfunctions, @safe_cfunction, @initcxx,
 ConstCxxPtr, ConstCxxRef, CxxRef, CxxPtr,

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -57,6 +57,9 @@ end
 
 @testset "$(basename(@__FILE__)[1:end-3])" begin
 
+@test isdir(CxxWrap.prefix_path())
+@test isfile(joinpath(CxxWrap.prefix_path(), "lib", "cmake", "JlCxx", "FindJulia.cmake"))
+
 # Test functions from the CppHalfFunctions module
 @test CppHalfFunctions.half_d(3) == 1.5
 @show methods(CppHalfFunctions.half_d)


### PR DESCRIPTION
It would be great if this could be merged and then 0.9.1 be released. Then once 0.10.1 is out with its own fixes for prefix_path, code which wants to be compatible with both 0.9 and 0.10 can write
```julia
jlcxx_cmake_dir = joinpath(CxxWrap.prefix_path(), "lib", "cmake", "JlCxx")
```
instead of monstrosities like this:
```julia
jlcxx_cmake_dir = joinpath(dirname(
                     isdefined(CxxWrap, :jlcxx_path) && !isempty(CxxWrap.jlcxx_path) ?
                     CxxWrap.jlcxx_path :
                     CxxWrap.CxxWrapCore.libcxxwrap_julia_jll.libcxxwrap_julia_path
                  ),"cmake","JlCxx")
```