### PR TITLE
Document the need to include const array header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,6 +775,7 @@ shows:
  2.0  5.0
  3.0  6.0
 ```
+An extra file has to be included to have constant array functionality: `#include "jlcxx/const_array.hpp"`.
 
 ### Mutable arrays
 


### PR DESCRIPTION
Mention in the README.md documentation the need to include an extra header file to enjoy constant
array functionality.