### PR TITLE
Reference presentations on CxxWrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,3 +926,7 @@ template<> struct IsMirroredType<Foo> : std::false_type { };
 ## Breaking changes in v0.10
 * Requires Julia 1.3 for the use of JLL packages
 * Reorganized integer types so the fixed-size types always map to built-in Julia types
+
+## References
+[JuliaCon 2020 Talk: Julia and C++: a technical overview of CxxWrap.jl](https://live.juliacon.org/talk/XGHSWW)
+[JuliaCon 2020 Workshop: Wrapping a C++ library using CxxWrap.jl](https://live.juliacon.org/talk/NNVQQF)


### PR DESCRIPTION
There are some notes in the presentation (I'm thinking specifically the "$(type)Dereferenced" types at  https://barche.github.io/juliacon2020-cxxwrap-talk/#/5/1/2 , but there are othres) that aren't mentioned in the README, so I think it is useful to add a reference to the talk.

I added the reference to the workshop for completeness.