### PR TITLE
Safecfunction naming

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CxxWrap"
 uuid = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 authors = ["Bart Janssens <bart@bartjanssens.org>"]
-version = "0.11.1"
+version = "0.11.2"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"


### PR DESCRIPTION
This improves upon PR #282 by making sure it is still safe to store a `SafeCFunction` and uses the proper `cconvert` and `unsafe_convert` mechanism.