### PR TITLE
Fix `==` ambiguity when overriden for a given type

### DIFF
--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -416,7 +416,7 @@ function initialize_julia_module(mod::Module)
   for func in funcs
     _register_function_pointers(func, precompiling)
   end
-  for (fidx,mkey) in enumerate(mod.__cxxwrap_methodkeys)    
+  for (fidx,mkey) in enumerate(mod.__cxxwrap_methodkeys)
     mod.__cxxwrap_pointers[fidx] = _get_function_pointer(mkey)
   end
 end
@@ -676,8 +676,8 @@ function wrap_reference_converters(julia_mod)
     Core.eval(julia_mod, :($(@__MODULE__).dereferenced_type(::Type{$st}) = $reftype))
     Core.eval(julia_mod, :(Base.convert(::Type{$st}, x::$bt) = x))
     Core.eval(julia_mod, :(Base.convert(::Type{$st}, x::$reftype) = x))
-    Core.eval(julia_mod, :(Base.:(==)(a::Union{CxxRef,ConstCxxRef,$bt}, b::$reftype) = (a.cpp_object == b.cpp_object)))
-    Core.eval(julia_mod, :(Base.:(==)(a::$reftype, b::Union{CxxRef,ConstCxxRef,$bt}) = (b == a)))
+    Core.eval(julia_mod, :(Base.:(==)(a::Union{CxxRef{<:$st},ConstCxxRef{<:$st},$bt}, b::$reftype) = (a.cpp_object == b.cpp_object)))
+    Core.eval(julia_mod, :(Base.:(==)(a::$reftype, b::Union{CxxRef{<:$st},ConstCxxRef{<:$st},$bt}) = (b == a)))
   end
 end
 

--- a/test/types.jl
+++ b/test/types.jl
@@ -223,8 +223,11 @@ _, _, _, _, memallocs = @timed bench_greet()
 
 if isdefined(CppTypes, :IntDerived)
   Base.promote_rule(::Type{<:CppTypes.IntDerived}, ::Type{<:Number}) = Int
-  @test CppTypes.IntDerived() == CppTypes.IntDerived()
-  @test CppTypes.IntDerived() == 42
+  intd = CppTypes.IntDerived()
+  @test intd == CppTypes.IntDerived()
+  @test intd == 42
+  intdref = CxxRef(intd)
+  @test intdref[] == intdref
 end
 
 let weq = CppTypes.World()


### PR DESCRIPTION
Leverages tests w.r.t. `IntDerived` since it specifies the `==` function with a method of its own, building upon them by comparing an `IntDerivedDereferenced` object with a `CxxRef{IntDerived}`.  The added test fails without this PR's additional change.

Fixes #250