### PR TITLE
Replace convert method for StdString to avoid invalidations

### DIFF
--- a/src/StdLib.jl
+++ b/src/StdLib.jl
@@ -103,7 +103,7 @@ Base.cmp(a::String, b::CppBasicString) = cmp(a,String(b))
 
 # Make sure functions taking a C++ string as argument can also take a Julia string
 CxxWrapCore.map_julia_arg_type(x::Type{<:StdString}) = AbstractString
-Base.convert(::Type{T}, x::String) where {T<:StdString} = StdString(x)
+StdLib.StdStringAllocated(x::String) = StdString(x)
 Base.cconvert(::Type{CxxWrapCore.ConstCxxRef{StdString}}, x::String) = StdString(x)
 Base.unsafe_convert(::Type{CxxWrapCore.ConstCxxRef{StdString}}, x::StdString) = ConstCxxRef(x)
 


### PR DESCRIPTION
The Julia stdlib provides the following convert method:

    convert(::Type{T}, s::T) where {T<:AbstractString} = s
    convert(::Type{T}, s::AbstractString) where {T<:AbstractString} = T(s)::T

Thus it suffices to provide a conversion constructor for StdStringAllocated.

This is better than a convert method, because the latter introduces
invalidations in other packages (specifically in packages which do *not*
use CxxWrap but which are loaded together with CxxWrap into the same
Julia session).

This is progress on issue #278.