### PR TITLE
Added support for Val{T}

### DIFF
--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -603,6 +603,7 @@ function build_function_expression(func::CppFunctionInfo, funcidx, julia_mod)
   map_c_arg_type(::Type{ConstArray{T,N}}) where {T,N} = Any
   map_c_arg_type(::Type{T}) where {T<:CxxNumber} = julia_int_type(T)
   map_c_arg_type(::Type{SafeCFunction}) = _SafeCFunction
+  map_c_arg_type(::Type{Val{T}}) where {T} = Any
 
   # Builds the return type passed to ccall
   map_c_return_type(t) = t

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -177,6 +177,14 @@ cppdref[] = 1.0
 @test CppTestFunctions.test_const_string_return() == "test"
 @test CppTestFunctions.test_datatype_conversion(Float64) == Float64
 
+@test CppTestFunctions.test_val(Val(Cint(1))) == 1
+@test CppTestFunctions.test_val(Val(Cint(2))) == 2
+@test CppTestFunctions.test_val(Val(Cshort(3))) == 3
+@test CppTestFunctions.test_val(Val(Cint(4))) == Val(Cint(4))
+@test CppTestFunctions.test_val(Val(:A)) === :A
+@test CppTestFunctions.test_val(Val(:B)) === :B
+@test CppTestFunctions.test_val(Val(:C)) == Val(:C)
+
 @test typeof(CppTestFunctions.test_double_pointer()) == CxxPtr{Float64}
 @test CppTestFunctions.test_double_pointer() == C_NULL
 @test typeof(CppTestFunctions.test_double2_pointer()) == CxxPtr{CxxPtr{Float64}}


### PR DESCRIPTION
Only one small change is required for to support Val{T} on the Julia side.
See https://github.com/JuliaInterop/libcxxwrap-julia/pull/123.