### PR TITLE
Trigger fresh precompilation when .so changes

### DIFF
--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -739,6 +739,7 @@ function readmodule(so_path::AbstractString, funcname, m::Module, flags)
   Core.eval(m, :(const __cxxwrap_flags = $flags))
   fptr = Libdl.dlsym(Libdl.dlopen(so_path, flags), funcname)
   register_julia_module(m, fptr)
+  include_dependency(so_path)
 end
 
 function wrapmodule(so_path::AbstractString, funcname, m::Module, flags)


### PR DESCRIPTION
Whenever the shared module with C++ code changes, this can mean that
functions or types were added/changed/removed. Forgetting to trigger a
precompilation can cause weird bugs during development. So let's just do
this automatically.
