### PR TITLE
Provide library path to wrapmodule via callback instead of a compile-time constant

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CxxWrap"
 uuid = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 authors = ["Bart Janssens <bart@bartjanssens.org>"]
-version = "0.13.4"
+version = "0.14.0"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Once this code is compiled into a shared library (say `libhello.so`) it can be u
 # Load the module and generate the functions
 module CppHello
   using CxxWrap
-  @wrapmodule(joinpath("path/to/built/lib","libhello"))
+  @wrapmodule(() -> joinpath("path/to/built/lib","libhello"))
 
   function __init__()
     @initcxx
@@ -120,12 +120,12 @@ In Julia, the name of the entry point must now be specified explicitly:
 ```julia
 module A
   using CxxWrap
-  @wrapmodule("mylib.so",:define_module_a)
+  @wrapmodule(() -> "mylib.so",:define_module_a)
 end
 
 module B
   using CxxWrap
-  @wrapmodule("mylib.so",:define_module_b)
+  @wrapmodule(() -> "mylib.so",:define_module_b)
 end
 ```
 
@@ -133,7 +133,7 @@ In specific cases, it may also be necessary to specify `dlopen` flags such as `R
 These can be supplied in a third, optional argument to `@wrapmodule`, e.g:
 
 ```julia
-@wrapmodule(CxxWrapCore.libcxxwrap_julia_stl, :define_cxxwrap_stl_module, Libdl.RTLD_GLOBAL)
+@wrapmodule(() -> CxxWrapCore.libcxxwrap_julia_stl, :define_cxxwrap_stl_module, Libdl.RTLD_GLOBAL)
 ```
 
 ## More extensive example and function call performance
@@ -677,7 +677,7 @@ using CxxWrap
 using Base.Test
 
 module Containers
-  @wrapmodule(libcontainers)
+  @wrapmodule(() -> libcontainers)
   export test_tuple
 end
 using Containers
@@ -843,7 +843,7 @@ To do this, call the `wrapmodule` method inside an appropriately named Julia mod
 module ExtendedTypes
 
 using CxxWrap
-@wrapmodule("libextended")
+@wrapmodule(() -> "libextended")
 export ExtendedWorld, greet
 
 end

--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -726,6 +726,11 @@ function wrapfunctions(jlmod)
   wrap_functions(module_functions, jlmod)
 end
 
+function readmodule(so_path::String, funcname, m::Module, flags)
+  Base.depwarn("Calling `@readmodule` with the path of the library to load is deprecated. Pass the name of a function returning the path instead, e.g. use `libfoo_jll.get_libfoo_path` instead of `libfoo_jll.libfoo`.", :readmodule; force=true)
+  readmodule(() -> so_path, funcname, m, flags)
+end
+
 function readmodule(so_path_cb::Function, funcname, m::Module, flags)
   if isdefined(m, :__cxxwrap_methodkeys)
     return
@@ -744,6 +749,11 @@ function readmodule(so_path_cb::Function, funcname, m::Module, flags)
   include_dependency(so_path)
 end
 
+function wrapmodule(so_path::String, funcname, m::Module, flags)
+  Base.depwarn("Calling `@wrapmodule` with the path of the library to load is deprecated. Pass the name of a function returning the path instead, e.g. use `libfoo_jll.get_libfoo_path` instead of `libfoo_jll.libfoo`.", :wrapmodule; force=true)
+  wrapmodule(() -> so_path, funcname, m, flags)
+end
+
 function wrapmodule(so_path_cb::Function, funcname, m::Module, flags)
   readmodule(so_path_cb, funcname, m, flags)
   wraptypes(m)
@@ -756,6 +766,10 @@ end
 Place the functions and types from the C++ lib into the module enclosing this macro call
 Calls an entry point named `define_julia_module`, unless another name is specified as
 the second argument.
+
+`libraryfile_cb` is a
+function that returns the shared library file to load as a string. In case of a JLL exporting `libfoo.so`
+it is possible to use `foo_jll.get_libfoo_path()`
 """
 macro wrapmodule(libraryfile_cb, register_func=:(:define_julia_module), flags=:(nothing))
   return :(wrapmodule($(esc(libraryfile_cb)), $(esc(register_func)), $__module__, $(esc(flags))))
@@ -764,7 +778,9 @@ end
 """
   @readmodule libraryfile_cb [functionname]
 
-Read a C++ module and associate it with the Julia module enclosing the macro call.
+Read a C++ module and associate it with the Julia module enclosing the macro call. `libraryfile_cb` is a
+function that returns the shared library file to load as a string. In case of a JLL exporting `libfoo.so`
+it is possible to use `foo_jll.get_libfoo_path()`
 """
 macro readmodule(libraryfile_cb, register_func=:(:define_julia_module), flags=:(nothing))
   return :(readmodule($(esc(libraryfile_cb)), $(esc(register_func)), $__module__, $(esc(flags))))

--- a/src/StdLib.jl
+++ b/src/StdLib.jl
@@ -14,7 +14,12 @@ function resize end
 
 import Libdl
 import libcxxwrap_julia_jll
-@wrapmodule(libcxxwrap_julia_jll.libcxxwrap_julia_stl, :define_cxxwrap_stl_module, Libdl.RTLD_GLOBAL)
+
+function get_libcxxwrap_julia_stl_path()::AbstractString
+  libcxxwrap_julia_jll.libcxxwrap_julia_stl
+end
+
+@wrapmodule(get_libcxxwrap_julia_stl_path, :define_cxxwrap_stl_module, Libdl.RTLD_GLOBAL)
 
 function __init__()
   @initcxx

--- a/test/basic_types.jl
+++ b/test/basic_types.jl
@@ -16,7 +16,7 @@ module BasicTypes
     y :: Float32
   end
 
-  @wrapmodule CxxWrap.CxxWrapCore.libbasic_types()
+  @wrapmodule CxxWrap.CxxWrapCore.libbasic_types
 
   function __init__()
     @initcxx

--- a/test/containers.jl
+++ b/test/containers.jl
@@ -8,7 +8,7 @@ end
 
 module Containers
   include(joinpath(@__DIR__, "testcommon.jl"))
-  @wrapmodule CxxWrap.CxxWrapCore.libjlcxx_containers()
+  @wrapmodule CxxWrap.CxxWrapCore.libjlcxx_containers
 
   function __init__()
     @initcxx

--- a/test/extended_module.jl
+++ b/test/extended_module.jl
@@ -3,7 +3,7 @@ module ExtendedTypes
 
 include(joinpath(@__DIR__, "testcommon.jl"))
 
-@readmodule CxxWrap.CxxWrapCore.libextended()
+@readmodule CxxWrap.CxxWrapCore.libextended
 @wraptypes
 @wrapfunctions
 

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -233,7 +233,7 @@ end
 half_julia(d::Float64) = d*0.5
 
 # C version
-half_c(d::Float64) = ccall((:half_c, CxxWrap.CxxWrapCore.libfunctions), Cdouble, (Cdouble,), d)
+half_c(d::Float64) = ccall((:half_c, CxxWrap.CxxWrapCore.libfunctions()), Cdouble, (Cdouble,), d)
 
 # Bring C++ versions into scope
 using .CppHalfFunctions: half_d, half_lambda, half_loop_cpp!, half_loop_jlcall!, half_loop_cfunc!

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -1,13 +1,11 @@
 include(joinpath(@__DIR__, "testcommon.jl"))
 cxx_available = false
 
-const functions_lib_path = CxxWrap.CxxWrapCore.libfunctions()
-
 # Wrap the functions defined in C++
 module CppHalfFunctions
   using CxxWrap
 
-  @wrapmodule(Main.functions_lib_path, :init_half_module)
+  @wrapmodule(CxxWrap.CxxWrapCore.libfunctions, :init_half_module)
 
   function __init__()
     @initcxx
@@ -17,7 +15,7 @@ end
 module CppTestFunctions
 
 using CxxWrap
-@wrapmodule(Main.functions_lib_path, :init_test_module)
+@wrapmodule(CxxWrap.CxxWrapCore.libfunctions, :init_test_module)
 
 function __init__()
     @initcxx
@@ -235,7 +233,7 @@ end
 half_julia(d::Float64) = d*0.5
 
 # C version
-half_c(d::Float64) = ccall((:half_c, functions_lib_path), Cdouble, (Cdouble,), d)
+half_c(d::Float64) = ccall((:half_c, CxxWrap.CxxWrapCore.libfunctions), Cdouble, (Cdouble,), d)
 
 # Bring C++ versions into scope
 using .CppHalfFunctions: half_d, half_lambda, half_loop_cpp!, half_loop_jlcall!, half_loop_cfunc!

--- a/test/hello.jl
+++ b/test/hello.jl
@@ -1,7 +1,7 @@
 # Wrap the functions defined in C++
 module CppHello
   include(joinpath(@__DIR__, "testcommon.jl"))
-  @wrapmodule CxxWrap.CxxWrapCore.libhello()
+  @wrapmodule CxxWrap.CxxWrapCore.libhello
 
   function __init__()
     @initcxx

--- a/test/inheritance.jl
+++ b/test/inheritance.jl
@@ -4,7 +4,7 @@ include(joinpath(@__DIR__, "testcommon.jl"))
 module CppInheritance
 
 using CxxWrap
-@wrapmodule(CxxWrap.CxxWrapCore.libinheritance(), :define_types_module)
+@wrapmodule(CxxWrap.CxxWrapCore.libinheritance, :define_types_module)
 
 function __init__()
   @initcxx
@@ -16,7 +16,7 @@ end
 
 module VirtualSolver
   using CxxWrap
-  @wrapmodule(CxxWrap.CxxWrapCore.libinheritance(), :define_vsolver_module)
+  @wrapmodule(CxxWrap.CxxWrapCore.libinheritance, :define_vsolver_module)
   
   function __init__()
     @initcxx

--- a/test/parametric.jl
+++ b/test/parametric.jl
@@ -4,7 +4,7 @@ include(joinpath(@__DIR__, "testcommon.jl"))
 module ParametricTypes
 
 using CxxWrap
-@wrapmodule(CxxWrap.CxxWrapCore.libparametric())
+@wrapmodule(CxxWrap.CxxWrapCore.libparametric)
 
 function __init__()
     @initcxx

--- a/test/pointer_modification.jl
+++ b/test/pointer_modification.jl
@@ -6,7 +6,7 @@ module PtrModif
   end
 
   include(joinpath(@__DIR__, "testcommon.jl"))
-  @wrapmodule CxxWrap.CxxWrapCore.libpointer_modification()
+  @wrapmodule CxxWrap.CxxWrapCore.libpointer_modification
 
   function __init__()
     @initcxx

--- a/test/types.jl
+++ b/test/types.jl
@@ -6,7 +6,7 @@ module CppTypes
 using CxxWrap
 
 GC.gc()
-@readmodule(CxxWrap.CxxWrapCore.libtypes())
+@readmodule(CxxWrap.CxxWrapCore.libtypes)
 @wraptypes
 @wrapfunctions
 GC.gc()
@@ -29,7 +29,7 @@ module CppTypes2
 
 using CxxWrap
 
-@wrapmodule CxxWrap.CxxWrapCore.libtypes() :define_types2_module
+@wrapmodule CxxWrap.CxxWrapCore.libtypes :define_types2_module
 
 function __init__()
   @initcxx
@@ -41,7 +41,7 @@ module CppTypes3
 
 using CxxWrap
 
-@wrapmodule CxxWrap.CxxWrapCore.libtypes() :define_types3_module
+@wrapmodule CxxWrap.CxxWrapCore.libtypes :define_types3_module
 
 function __init__()
   @initcxx


### PR DESCRIPTION
This fixes `PackageCompiler` relocatability issues described in #333 