### PR TITLE
use `cppsize` when constructing `String` from `StdString`

### DIFF
--- a/src/StdLib.jl
+++ b/src/StdLib.jl
@@ -101,7 +101,7 @@ end
   return v
 end
 
-@cxxdereference Base.String(s::StdString) = unsafe_string(reinterpret(Ptr{Cchar},c_str(s).cpp_object))
+@cxxdereference Base.String(s::StdString) = unsafe_string(reinterpret(Ptr{Cchar},c_str(s).cpp_object), cppsize(s))
 @cxxdereference function Base.String(s::StdWString)
   chars = unsafe_wrap(Vector{Cwchar_t}, reinterpret(Ptr{Cwchar_t},c_str(s).cpp_object), (cppsize(s),))
   return transcode(String, chars)

--- a/src/StdLib.jl
+++ b/src/StdLib.jl
@@ -112,9 +112,10 @@ Base.cmp(a::String, b::CppBasicString) = cmp(a,String(b))
 
 # Make sure functions taking a C++ string as argument can also take a Julia string
 CxxWrapCore.map_julia_arg_type(x::Type{<:StdString}) = AbstractString
-StdLib.StdStringAllocated(x::String) = StdString(x,length(x))
-Base.cconvert(::Type{CxxWrapCore.ConstCxxRef{StdString}}, x::String) = StdString(x,length(x))
-Base.cconvert(::Type{StdLib.StdStringDereferenced}, x::String) = StdString(x,length(x))
+StdString(x::String) = StdString(x,ncodeunits(x))
+StdLib.StdStringAllocated(x::String) = StdString(x,ncodeunits(x))
+Base.cconvert(::Type{CxxWrapCore.ConstCxxRef{StdString}}, x::String) = StdString(x,ncodeunits(x))
+Base.cconvert(::Type{StdLib.StdStringDereferenced}, x::String) = StdString(x,ncodeunits(x))
 Base.unsafe_convert(::Type{CxxWrapCore.ConstCxxRef{StdString}}, x::StdString) = ConstCxxRef(x)
 
 function StdValArray(v::Vector{T}) where {T}

--- a/src/StdLib.jl
+++ b/src/StdLib.jl
@@ -112,9 +112,9 @@ Base.cmp(a::String, b::CppBasicString) = cmp(a,String(b))
 
 # Make sure functions taking a C++ string as argument can also take a Julia string
 CxxWrapCore.map_julia_arg_type(x::Type{<:StdString}) = AbstractString
-StdLib.StdStringAllocated(x::String) = StdString(x)
-Base.cconvert(::Type{CxxWrapCore.ConstCxxRef{StdString}}, x::String) = StdString(x)
-Base.cconvert(::Type{StdLib.StdStringDereferenced}, x::String) = StdString(x)
+StdLib.StdStringAllocated(x::String) = StdString(x,length(x))
+Base.cconvert(::Type{CxxWrapCore.ConstCxxRef{StdString}}, x::String) = StdString(x,length(x))
+Base.cconvert(::Type{StdLib.StdStringDereferenced}, x::String) = StdString(x,length(x))
 Base.unsafe_convert(::Type{CxxWrapCore.ConstCxxRef{StdString}}, x::StdString) = ConstCxxRef(x)
 
 function StdValArray(v::Vector{T}) where {T}

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -38,6 +38,14 @@ let s = StdString("foo")
   @test unsafe_string(CxxWrap.StdLib.c_str(s),2) == "fo"
 end
 
+let s = "\x01\x00\x02"
+    @test length(StdString) == 1
+    @test length(StdString(s, length(s))) == 3
+
+    @test String(StdString(s)) != s
+    @test String(StdString(s, length(s))) == s
+end
+
 stvec = StdVector(Int32[1,2,3])
 @test all(stvec .== [1,2,3])
 push!(stvec,1)

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -39,7 +39,7 @@ let s = StdString("foo")
 end
 
 let s = "\x01\x00\x02"
-    @test length(StdString) == 1
+    @test length(StdString(s)) == 1
     @test length(StdString(s, length(s))) == 3
 
     @test String(StdString(s)) != s

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -39,10 +39,10 @@ let s = StdString("foo")
 end
 
 let s = "\x01\x00\x02"
-    @test length(StdString(s)) == 1
+    @test length(StdString(s)) == 3
     @test length(StdString(s, length(s))) == 3
 
-    @test String(StdString(s)) != s
+    @test String(StdString(s)) == s
     @test String(StdString(s, length(s))) == s
 end
 


### PR DESCRIPTION
Currently, `std::string`s that have null bytes in them cannot be converted to `String`s without truncation using the StdLib-provided `String` constructor.  `Base.unsafe_string` with one argument assumes the pointed-to string is null-terminated, but `std::string`s are not necessarily null-terminated.  `Base.unsafe_string` supports an optional second argument (thanks @omus for pointing this out!) which is the number of bytes in the pointed-to string; this PR uses `cppsize` to get that.  I've also added some small tests to confirm how null-byte containing strings are handled (from the `String`-to-`std::string` direction and vice-versa); I didn't change the default `StdString` constructor to use the length of the julia `String`, although IMO whether that default should be changed is IMO up for debate, but given that it's already supported and the `length`-less method is the default I'm assuming that's for a good reason.

This change is technically breaking: if you were relying on the (IMO bugged) behavior of `String(::StdString)` discarding anything starting from the first null byte, you'll get different behavior.  How you want to handle the version bump here is up to you; I'd probably release it as a patch (bugfix) but for something that's deep in some fiddly codebases it might be better to be safe rather than sorry here.

If you _do_ want to make a breaking release with this, I'd also change the handling of the `String`-to-`StdString` method to use the string length by default, but as with this change that's breaking.

The handling of null bytes has bitten us quite a few times though, interacting with APIs taht generate strings with null bytes in them introduces very weird and difficult to debug errors.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205632518214421