### PR TITLE
Handle UTF-8 code points in `StdString`

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,8 +904,7 @@ Linking wrappers using STL support requires adding `JlCxx::cxxwrap_julia_stl` to
 
 ### Working with `StdString`
 
-The `StdString` implements the Julia string interface and interprets `std::string` data as UTF-8 data. 
-Since C++ strings do not require the use of the null-character to denote the end of a string the `StdString` constructors usually rely on the `ncodeunits` to determin the size of the string. When constructing a `StdString` from a `Cstring`, `Base.CodeUnits`, or `Vector{UInt8}` the first null-character present will denote the end of the string.
+The `StdString` implements the Julia string interface and interprets `std::string` data as UTF-8 data. Since C++ strings do not require the use of the null-character to denote the end of a string the `StdString` constructors usually rely on the `ncodeunits` to determin the size of the string. When constructing a `StdString` from a `Cstring`, `Base.CodeUnits`, or `Vector{UInt8}` the first null-character present will denote the end of the string.
 
 ## Release procedure
 

--- a/README.md
+++ b/README.md
@@ -902,6 +902,11 @@ mod.method("getSecondaryWorldVector", [](const World* p)->const std::vector<Worl
 
 Linking wrappers using STL support requires adding `JlCxx::cxxwrap_julia_stl` to the `target_link_libraries` command in `CMakeLists.txt`.
 
+### Working with `StdString`
+
+The `StdString` implements the Julia string interface and interprets `std::string` data as UTF-8 data. 
+Since C++ strings do not require the use of the null-character to denote the end of a string the `StdString` constructors usually rely on the `ncodeunits` to determin the size of the string. When constructing a `StdString` from a `Cstring`, `Base.CodeUnits`, or `Vector{UInt8}` the first null-character present will denote the end of the string.
+
 ## Release procedure
 
 Often, new releases of `CxxWrap` also require a new release of the C++ component `libcxxwrap-julia`, and a rebuild of its JLL package. To make sure everything is tested properly, the following procedure should be followed for each release that requires changing both the Julia and the C++ component:

--- a/src/StdLib.jl
+++ b/src/StdLib.jl
@@ -47,7 +47,7 @@ end
 
 function Base.iterate(s::StdString, i::Integer=firstindex(s))
   i > ncodeunits(s) && return nothing
-  j = nextind(s, i)
+  j = isvalid(s, i) ? nextind(s, i) : i + 1
   u = UInt32(codeunit(s, i)) << 24
   (i += 1) < j || @goto ret
   u |= UInt32(codeunit(s, i)) << 16

--- a/src/StdLib.jl
+++ b/src/StdLib.jl
@@ -45,6 +45,9 @@ function Base.iterate(s::CppBasicString, i::Integer=firstindex(s))
   return convert(Char, codeunit(s, i)), nextind(s, i)
 end
 
+# Since the Julia base string iteration is `String` specific we need to implement our own.
+# This implementation is based around a functioning `nextind` which allows us to convert the
+# UTF-8 codeunits into their big-endian encoding.
 function Base.iterate(s::StdString, i::Integer=firstindex(s))
   i > ncodeunits(s) && return nothing
   j = isvalid(s, i) ? nextind(s, i) : i + 1

--- a/src/StdLib.jl
+++ b/src/StdLib.jl
@@ -36,15 +36,13 @@ Base.ncodeunits(s::CppBasicString)::Int = cppsize(s)
 Base.codeunit(s::StdString) = UInt8
 Base.codeunit(s::StdWString) = Cwchar_t == Int32 ? UInt32 : UInt16
 Base.codeunit(s::CppBasicString, i::Integer) = reinterpret(codeunit(s), cxxgetindex(s,i))
-Base.isvalid(s::CppBasicString, i::Integer) = 0 < i <= ncodeunits(s)
-Base.isvalid(s::StdString, i::Int) = checkbounds(Bool, s, i) && thisind(s, i) == i
-
-Base.thisind(s::StdString, i::Int) = Base._thisind_str(s, i)
-Base.nextind(s::StdString, i::Int) = Base._nextind_str(s, i)
+Base.isvalid(s::CppBasicString, i::Int) = checkbounds(Bool, s, i) && thisind(s, i) == i
+Base.thisind(s::CppBasicString, i::Int) = Base._thisind_str(s, i)
+Base.nextind(s::CppBasicString, i::Int) = Base._nextind_str(s, i)
 
 function Base.iterate(s::CppBasicString, i::Integer=firstindex(s))
-  isvalid(s, i) || return nothing
-  return convert(Char, codeunit(s, i)), i+1
+  i > ncodeunits(s) && return nothing
+  return convert(Char, codeunit(s, i)), nextind(s, i)
 end
 
 function Base.iterate(s::StdString, i::Integer=firstindex(s))
@@ -61,9 +59,7 @@ function Base.iterate(s::StdString, i::Integer=firstindex(s))
   return reinterpret(Char, u), j
 end
 
-Base.getindex(s::CppBasicString, i::Int) = Char(cxxgetindex(s,i))
-
-function Base.getindex(s::StdString, i::Int)
+function Base.getindex(s::CppBasicString, i::Int)
   checkbounds(s, i)
   isvalid(s, i) || Base.string_index_err(s, i)
   c, i = iterate(s, i)

--- a/src/StdLib.jl
+++ b/src/StdLib.jl
@@ -140,7 +140,7 @@ CxxWrapCore.map_julia_arg_type(x::Type{<:StdString}) = AbstractString
 """
     StdString(str::String)
 
-Create a new `StdString` from the contents of the string. Any null-characters will be
+Create a `StdString` from the contents of the string. Any null-characters ('\\0') will be
 included in the string such that `ncodeunits(str) == ncodeunits(StdString(str))`.
 """
 StdString(x::String) = StdString(x, ncodeunits(x))
@@ -148,12 +148,15 @@ StdString(x::String) = StdString(x, ncodeunits(x))
 """
     StdString(str::Union{Cstring, Base.CodeUnits, Vector{UInt8}, Ref{Int8}, Array{Int8}})
 
-Create a new `StdString` from the null-terminated character sequence.
+Create a `StdString` from the null-terminated character sequence.
+
+If you want to  construct a `StdString` that includes the null-character ('\\0') either use
+[`StdString(::String)`](@ref) or [`StdString(::Any, ::Int)`](@ref).
 
 ## Examples
 
 ```julia
-julia> StdString(b"visible\0hidden")
+julia> StdString(b"visible\\0hidden")
 "visible"
 ```
 """
@@ -162,6 +165,20 @@ StdString(::Union{Cstring, Base.CodeUnits, Vector{UInt8}, Ref{Int8}, Array{Int8}
 StdString(x::Cstring) = StdString(convert(Ptr{Int8}, x))
 StdString(x::Base.CodeUnits) = StdString(collect(x))
 StdString(x::Vector{UInt8}) = StdString(collect(reinterpret(Int8, x)))
+
+"""
+    StdString(str, n::Integer)
+
+Create a `StdString` from the first `n` code units of `str` (including null-characters).
+
+## Examples
+
+```julia
+julia> StdString("visible\\0hidden", 10)
+"visible\\0hi"
+```
+"""
+StdString(::Any, ::Integer)
 
 Base.cconvert(::Type{CxxWrapCore.ConstCxxRef{StdString}}, x::String) = StdString(x, ncodeunits(x))
 Base.cconvert(::Type{StdLib.StdStringDereferenced}, x::String) = StdString(x, ncodeunits(x))

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -84,7 +84,7 @@ let str = "α\0β"
 
   std_str = StdString(str, 4)
   @test length(std_str) == 3
-  @test collect(std_str) == ['α', '\0', '\xce']
+  @test collect(std_str) == ['α', '\0', malformed_char(0xce)]
   @test ncodeunits(std_str) == 4
   @test codeunits(std_str) == b"α\0\xce"
 

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -101,6 +101,8 @@ end
 @testset "StdWString" begin
   @testset "iterate" begin
     s = StdWString("😄")
+    @show codeunits(s) ncodeunits(s)
+    @show collect(s) length(s)
     @test iterate(s) == ('😄', 2)
     @test iterate(s, firstindex(s)) == ('😄', 2)
     @test iterate(s, 2) === nothing

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -43,13 +43,13 @@ let s = StdString("foo")
 end
 
 let str = "\x01\x00\x02"
-  std_str = StdString(str)
+  std_str = StdString(codeunits(str))
   @test length(std_str) == 1
   @test collect(std_str) == ['\x01']
   @test ncodeunits(std_str) == 1
   @test codeunits(std_str) == b"\x01"
 
-  std_str = StdString(str , ncodeunits(str))
+  std_str = StdString(str)
   @test length(std_str) == 3
   @test collect(std_str) == ['\x01', '\x00', '\x02']
   @test ncodeunits(std_str) == 3
@@ -64,13 +64,13 @@ let str = "\x01\x00\x02"
 end
 
 let str = "α\0β"
-  std_str = StdString(str)
+  std_str = StdString(codeunits(str))
   @test length(std_str) == 1
   @test collect(std_str) == ['α']
   @test ncodeunits(std_str) == 2
   @test codeunits(std_str) == b"α"
 
-  std_str = StdString(str, ncodeunits(str))
+  std_str = StdString(str)
   @test length(std_str) == 3
   @test collect(std_str) == ['α', '\0', 'β']
   @test ncodeunits(std_str) == 5
@@ -85,6 +85,13 @@ let str = "α\0β"
 end
 
 @testset "StdString" begin
+  @testset "null-terminated constructors" begin
+    c_str = Cstring(Base.unsafe_convert(Ptr{Cchar}, "visible\0hidden"))
+    @test StdString(c_str) == "visible"
+    @test StdString(b"visible\0hidden") == "visible"
+    @test StdString(UInt8[0xff, 0x00, 0xff]) == "\xff"
+  end
+
   @testset "iterate" begin
     s = StdString("𨉟")
     @test iterate(s) == ('𨉟', 5)

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -55,6 +55,12 @@ let str = "\x01\x00\x02"
   @test ncodeunits(std_str) == 3
   @test codeunits(std_str) == b"\x01\x00\x02"
 
+  std_str = StdString(str, 2)
+  @test length(std_str) == 2
+  @test collect(std_str) == ['\x01', '\x00']
+  @test ncodeunits(std_str) == 2
+  @test codeunits(std_str) == b"\x01\x00"
+
   std_str = convert(StdString, str)
   @test length(std_str) == 3
   @test collect(std_str) == ['\x01', '\x00', '\x02']
@@ -75,6 +81,12 @@ let str = "α\0β"
   @test collect(std_str) == ['α', '\0', 'β']
   @test ncodeunits(std_str) == 5
   @test codeunits(std_str) == b"α\0β"
+
+  std_str = StdString(str, 4)
+  @test length(std_str) == 3
+  @test collect(std_str) == ['α', '\0', '\xce']
+  @test ncodeunits(std_str) == 4
+  @test codeunits(std_str) == b"α\0\xce"
 
   std_str = convert(StdString, str)
   @test length(std_str) == 3

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -85,7 +85,7 @@ end
     s = StdString("α")
     @test iterate(s) == ('α', 3)
     @test iterate(s, firstindex(s)) == ('α', 3)
-    @test iterate(s, 2) == ('\xb1', 3)
+    @test iterate(s, 2) == (first("\xb1"), 3)
     @test iterate(s, 3) === nothing
     @test iterate(s, typemax(Int)) === nothing
   end

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -98,6 +98,22 @@ end
   end
 end
 
+@testset "StdWString" begin
+  @testset "iterate" begin
+    s = StdWString("😄")
+    @test iterate(s) == ('😄', 2)
+    @test iterate(s, firstindex(s)) == ('😄', 2)
+    @test iterate(s, 2) === nothing
+    @test iterate(s, typemax(Int)) === nothing
+  end
+
+  @testset "getindex" begin
+    s = StdWString("😄")
+    @test getindex(s, firstindex(s)) == '😄'
+    @test_throws BoundsError getindex(s, 2)
+  end
+end
+
 stvec = StdVector(Int32[1,2,3])
 @test all(stvec .== [1,2,3])
 push!(stvec,1)

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -100,18 +100,18 @@ end
 
 @testset "StdWString" begin
   @testset "iterate" begin
-    s = StdWString("😄")
-    @show codeunits(s) ncodeunits(s)
-    @show collect(s) length(s)
-    @test iterate(s) == ('😄', 2)
-    @test iterate(s, firstindex(s)) == ('😄', 2)
+    char = codeunit(StdWString()) == UInt32 ? '😄' : 'α'
+    s = StdWString(string(char))
+    @test iterate(s) == (char, 2)
+    @test iterate(s, firstindex(s)) == (char, 2)
     @test iterate(s, 2) === nothing
     @test iterate(s, typemax(Int)) === nothing
   end
 
   @testset "getindex" begin
-    s = StdWString("😄")
-    @test getindex(s, firstindex(s)) == '😄'
+    char = codeunit(StdWString()) == UInt32 ? '😄' : 'α'
+    s = StdWString(string(char))
+    @test getindex(s, firstindex(s)) == char
     @test_throws BoundsError getindex(s, 2)
   end
 end


### PR DESCRIPTION
Update `StdString` Julia string interface to handle UTF-8 code points. For example on CxxWrap 0.14:

```julia
julia> using CxxWrap

julia> str = "¿\0ÿ"
"¿\0ÿ"

julia> codeunits(str)
5-element Base.CodeUnits{UInt8, String}:
 0xc2
 0xbf
 0x00
 0xc3
 0xbf

julia> std_str = StdString(str, ncodeunits(str))
"¿"

julia> collect(std_str)
5-element Vector{Char}:
 'Â': Unicode U+00C2 (category Lu: Letter, uppercase)
 '¿': Unicode U+00BF (category Po: Punctuation, other)
 '\0': ASCII/Unicode U+0000 (category Cc: Other, control)
 'Ã': Unicode U+00C3 (category Lu: Letter, uppercase)
 '¿': Unicode U+00BF (category Po: Punctuation, other)

julia> codeunits(std_str)
5-element Base.CodeUnits{UInt8, CxxWrap.StdLib.StdStringAllocated}:
 0xc2
 0xbf
 0x00
 0xc3
 0xbf

julia> String(codeunits(std_str))
"¿\0ÿ"

julia> convert(String, convert(StdString, "¿\0ÿ"))
"¿"
```

This PR includes the following changes:

- Support UTF-8 in `StdString` (https://en.m.wikipedia.org/wiki/C%2B%2B_string_handling#Standard_string_types)
- Support c-string constructor (null-character terminated string) (e.g. [`std::string (const char* s)`](https://cplusplus.com/reference/string/string/string/)) separate from`StdString(::String)`.
- Support lossless conversions between `String` and `StdString`.
- Docstrings for `StdString` explaining the intended behaviour of the new constructors.