### PR TITLE
Stop `@cxxdereference` from messing up linenum information

### DIFF
--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -843,7 +843,7 @@ macro cxxdereference(f)
   fdict[:kwargs] .= maparg.(fdict[:kwargs])
 
   # Dereference the arguments
-  deref_expr = quote end
+  deref_expr = Expr(:block)
   for arg in vcat(fdict[:args], fdict[:kwargs])
     (argname, _, slurp, _) = MacroTools.splitarg(arg)
     if argname === nothing


### PR DESCRIPTION
Makes a minor modification to `@cxxdeference` to stop that macro from add in line number information which blocks convenient macros likes `@which` and `@edit` from working properly:

```julia
julia> using CxxWrap

julia> foo() = 1
foo (generic function with 1 method)

julia> @which foo()
foo()
     @ Main REPL[2]:1

julia> @cxxdereference foo() = 1
foo (generic function with 1 method)

julia> @which foo()
foo()
     @ Main ~/.julia/packages/CxxWrap/VnssN/src/CxxWrap.jl:846

julia> @macroexpand @cxxdereference foo() = 1
:(function foo(; )
      #= /Users/cvogt/.julia/packages/CxxWrap/VnssN/src/CxxWrap.jl:846 =#
      #= REPL[8]:1 =#
      1
  end)
```
With this PR:
```julia
julia> using CxxWrap

julia> @cxxdereference foo() = 1
foo (generic function with 1 method)

julia> @which foo()
foo()
     @ Main REPL[2]:1
```