### PR TITLE
Parameterized constructors for `StdVector`

### DIFF
--- a/src/StdLib.jl
+++ b/src/StdLib.jl
@@ -74,7 +74,7 @@ function StdWString(s::String)
   StdWString(char_arr, length(char_arr))
 end
 
-function StdVector{T}(v::Union{Vector{<:T},Vector{CxxRef{T}}}) where {T}
+function StdVector{T}(v::Union{Vector{T},Vector{CxxRef{T}}}) where {T}
   result = StdVector{T}()
   isempty(v) || append(result, v)
   return result

--- a/src/StdLib.jl
+++ b/src/StdLib.jl
@@ -88,8 +88,8 @@ function StdVector(v::Vector{CxxRef{T}}) where {T}
 end
 
 function StdVector(v::Vector{T}) where {T}
-    S = if CxxWrapCore.cpp_trait_type(T) == CxxWrapCore.IsCxxType
-      isconcretetype(T) ? supertype(T) : T
+    S = if isconcretetype(T) && CxxWrapCore.cpp_trait_type(T) == CxxWrapCore.IsCxxType
+      supertype(T)
     else
       T
     end

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -191,8 +191,8 @@ end
     @test vec == ["a", "b", "c"]
 
     @test_throws MethodError StdVector{Bool}([true])
-    @test_throws MethodError StdVector{typeof(svec_alloc)}(svec_alloc)
-    @test_throws MethodError StdVector{typeof(svec_deref)}(svec_deref)
+    @test_throws MethodError StdVector{eltype(svec_alloc)}(svec_alloc)
+    @test_throws MethodError StdVector{eltype(svec_deref)}(svec_deref)
   end
 
   @testset "constructors" begin

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -167,18 +167,24 @@ end
     @test vec isa StdVector{StdString}
     @test vec == ["a", "b", "c"]
 
-    str_refs = CxxRef.(StdString["a", "b", "c"])
-    vec = StdVector{StdString}(str_refs)
+    svec_alloc = StdString.(["a", "b", "c"])::Vector{CxxWrap.StdLib.StdStringAllocated}
+    vec = StdVector{StdString}(svec_alloc)
     @test vec isa StdVector{StdString}
     @test vec == ["a", "b", "c"]
 
-    vec = StdVector{StdString}(getindex.(str_refs))
+    svec_ref = CxxRef.(StdString["a", "b", "c"])
+    vec = StdVector{StdString}(svec_ref)
+    @test vec isa StdVector{StdString}
+    @test vec == ["a", "b", "c"]
+
+    svec_deref = getindex.(svec_ref)::Vector{CxxWrap.StdLib.StdStringDereferenced}
+    vec = StdVector{StdString}(svec_deref)
     @test vec isa StdVector{StdString}
     @test vec == ["a", "b", "c"]
 
     @test_throws MethodError StdVector{Bool}([true])
-    @test_throws MethodError StdVector{CxxWrap.StdLib.StdStringAllocated}(StdString["a"])
-    @test_throws MethodError StdVector{CxxWrap.StdLib.StdStringDereferenced}(getindex.(str_refs))
+    @test_throws MethodError StdVector{typeof(svec_alloc)}(svec_alloc)
+    @test_throws MethodError StdVector{typeof(svec_deref)}(svec_deref)
   end
 
   @testset "constructors" begin
@@ -204,14 +210,22 @@ end
     @test vec isa StdVector{StdString}
     @test vec == ["a", "b", "c"]
 
-    str_refs = CxxRef.(StdString["a", "b", "c"])
-    vec = StdVector(str_refs)
+    svec_alloc = StdString.(["a", "b", "c"])::Vector{CxxWrap.StdLib.StdStringAllocated}
+    vec = StdVector(svec_alloc)
     @test vec isa StdVector{StdString}
     @test vec == ["a", "b", "c"]
 
-    vec = StdVector(getindex.(str_refs))
+    svec_ref = CxxRef.(StdString["a", "b", "c"])
+    vec = StdVector(svec_ref)
     @test vec isa StdVector{StdString}
     @test vec == ["a", "b", "c"]
+
+    svec_deref = getindex.(svec_ref)::Vector{CxxWrap.StdLib.StdStringDereferenced}
+    vec = StdVector(svec_deref)
+    @test vec isa StdVector{StdString}
+    @test vec == ["a", "b", "c"]
+
+    @test_throws MethodError StdVector(["a", "b", "c"])
   end
 
   @testset "mutating with integer" begin

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -142,10 +142,68 @@ end
 end
 
 @testset "StdVector" begin
+  @testset "parameterized constructors" begin
+    vec = StdVector{Int}()
+    @test vec isa StdVector{Int}
+    @test isempty(vec)
+
+    vec = StdVector{Int}([1,2,3])
+    @test vec isa StdVector{Int}
+    @test vec == [1,2,3]
+
+    vec = StdVector{Float64}([1,2,3])
+    @test vec isa StdVector{Float64}
+    @test vec == [1.0,2.0,3.0]
+
+    vec = StdVector{CxxBool}([true, false, true])
+    @test vec isa StdVector{CxxBool}
+    @test vec == [true, false, true]
+
+    vec = StdVector{StdString}(["a", "b", "c"])
+    @test vec isa StdVector{StdString}
+    @test vec == ["a", "b", "c"]
+
+    str_refs = CxxRef.(StdString["a", "b", "c"])
+    vec = StdVector{StdString}(str_refs)
+    @test vec isa StdVector{StdString}
+    @test vec == ["a", "b", "c"]
+
+    vec = StdVector{StdString}(getindex.(str_refs))
+    @test vec isa StdVector{StdString}
+    @test vec == ["a", "b", "c"]
+
+    @test_throws MethodError StdVector{Bool}([true])
+    @test_throws MethodError StdVector{CxxWrap.StdLib.StdStringAllocated}(StdString["a"])
+    @test_throws MethodError StdVector{CxxWrap.StdLib.StdStringDereferenced}(getindex.(str_refs))
+  end
+
   @testset "constructors" begin
-    @test StdVector([1,2,3]) == [1,2,3]
-    @test StdVector([1.0, 2.0, 3.0]) == [1,2,3]
-    @test StdVector([true, false, true]) == [true, false, true]
+    @test_throws MethodError StdVector()
+
+    vec = StdVector([1,2,3])
+    @test vec isa StdVector{Int}
+    @test vec == [1,2,3]
+
+    vec = StdVector([1.0, 2.0, 3.0])
+    @test vec isa StdVector{Float64}
+    @test vec == [1,2,3]
+
+    vec = StdVector([true, false, true])
+    @test vec isa StdVector{CxxBool}
+    @test vec == [true, false, true]
+
+    vec = StdVector(StdString["a", "b", "c"])
+    @test vec isa StdVector{StdString}
+    @test vec == ["a", "b", "c"]
+
+    str_refs = CxxRef.(StdString["a", "b", "c"])
+    vec = StdVector(str_refs)
+    @test vec isa StdVector{StdString}
+    @test vec == ["a", "b", "c"]
+
+    vec = StdVector(getindex.(str_refs))
+    @test vec isa StdVector{StdString}
+    @test vec == ["a", "b", "c"]
   end
 
   @testset "mutating with integer" begin

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -141,34 +141,45 @@ end
   end
 end
 
-stvec = StdVector(Int32[1,2,3])
-@test all(stvec .== [1,2,3])
-push!(stvec,1)
-@test all(stvec .== [1,2,3,1])
-resize!(stvec,2)
-@test all(stvec .== [1,2])
-append!(stvec,Int32[2,1])
-@test all(stvec .== [1,2,2,1])
-empty!(stvec)
-@test isempty(stvec)
+@testset "StdVector" begin
+  @testset "constructors" begin
+    @test StdVector([1,2,3]) == [1,2,3]
+    @test StdVector([1.0, 2.0, 3.0]) == [1,2,3]
+    @test StdVector([true, false, true]) == [true, false, true]
+  end
 
-@test all(StdVector([1,2,3]) .== [1,2,3])
-@test all(StdVector([1.0,2.0,3.0]) .== [1,2,3])
-@test all(StdVector([true, false, true]) .== [true, false, true])
-bvec = StdVector([true, false, true])
-append!(bvec, [true])
-@test all(bvec .== [true, false, true, true])
+  @testset "mutating with integer" begin
+    stvec = StdVector(Int32[1,2,3])
+    @test stvec == [1,2,3]
+    push!(stvec,1)
+    @test stvec == [1,2,3,1]
+    resize!(stvec, 2)
+    @test stvec == [1,2]
+    append!(stvec, Int32[2,1])
+    @test stvec == [1,2,2,1]
+    empty!(stvec)
+    @test isempty(stvec)
+  end
 
-cxxstrings = StdString["one", "two", "three"]
-svec = StdVector(CxxRef.(cxxstrings))
-@test all(svec .== ["one", "two", "three"])
-push!(svec, StdString("four"))
-@test all(svec .== ["one", "two", "three", "four"])
-cxxappstrings = StdString["five", "six"]
-append!(svec, CxxRef.(cxxappstrings))
-@test all(svec .== ["one", "two", "three", "four", "five", "six"])
-empty!(svec)
-@test isempty(svec)
+  @testset "mutating with bool" begin
+    bvec = StdVector([true, false, true])
+    append!(bvec, [true])
+    @test bvec == [true, false, true, true]
+  end
+
+  @testset "mutating with StdString" begin
+    cxxstrings = StdString["one", "two", "three"]
+    svec = StdVector(CxxRef.(cxxstrings))
+    @test svec == ["one", "two", "three"]
+    push!(svec, StdString("four"))
+    @test svec == ["one", "two", "three", "four"]
+    cxxappstrings = StdString["five", "six"]
+    append!(svec, CxxRef.(cxxappstrings))
+    @test svec == ["one", "two", "three", "four", "five", "six"]
+    empty!(svec)
+    @test isempty(svec)
+  end
+end
 
 stvec = StdVector(Int32[1,2,3])
 for vref in (CxxRef(stvec), CxxPtr(stvec))

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -147,6 +147,14 @@ end
     @test vec isa StdVector{Int}
     @test isempty(vec)
 
+    vec = StdVector{Int}([])
+    @test vec isa StdVector{Int}
+    @test isempty(vec)
+
+    vec = StdVector{Any}([])
+    @test vec isa StdVector{Any}
+    @test isempty(vec)
+
     vec = StdVector{Int}([1,2,3])
     @test vec isa StdVector{Int}
     @test vec == [1,2,3]
@@ -189,6 +197,14 @@ end
 
   @testset "constructors" begin
     @test_throws MethodError StdVector()
+
+    vec = StdVector(Int[])
+    @test vec isa StdVector{Int}
+    @test isempty(vec)
+
+    vec = StdVector(Any[])
+    @test vec isa StdVector{Any}
+    @test isempty(vec)
 
     vec = StdVector([1,2,3])
     @test vec isa StdVector{Int}

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -151,6 +151,10 @@ end
     @test vec isa StdVector{Int}
     @test vec == [1,2,3]
 
+    vec = StdVector{Any}([1,2,3])
+    @test vec isa StdVector{Any}
+    @test vec == [1,2,3]
+
     vec = StdVector{Float64}([1,2,3])
     @test vec isa StdVector{Float64}
     @test vec == [1.0,2.0,3.0]
@@ -182,6 +186,10 @@ end
 
     vec = StdVector([1,2,3])
     @test vec isa StdVector{Int}
+    @test vec == [1,2,3]
+
+    vec = StdVector(Any[1,2,3])
+    @test vec isa StdVector{Any}
     @test vec == [1,2,3]
 
     vec = StdVector([1.0, 2.0, 3.0])


### PR DESCRIPTION
Fixes https://github.com/JuliaInterop/CxxWrap.jl/issues/367. With this PR the `StdVector` constructors now support specifying the element type of the vector. Additionally, I've refactored the code to be more inlined with how `Vector` behaves and have added a more extensive test suite.

Example of the new behaviour of this PR using the examples from #357:
```julia
julia> StdVector{StdString}()
0-element CxxWrap.StdLib.StdVectorAllocated{StdString}

julia> StdVector(StdString[])
0-element CxxWrap.StdLib.StdVectorAllocated{StdString}

julia> StdVector(StdString["hello"])
1-element CxxWrap.StdLib.StdVectorAllocated{StdString}:
 "hello"

julia> StdVector{StdString}(StdString["hello"])
1-element CxxWrap.StdLib.StdVectorAllocated{StdString}:
 "hello"
```