### PR TITLE
Support for argument names, keyword arguments and argument default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,11 @@ CppTypes.set(w, "hello")
 ```
 
 The manually added constructor using the `constructor` function also creates a finalizer.
-This can be disabled by adding the argument `false`:
+This can be disabled by adding the argument `jlcxx::finalize_policy::no`:
 
 ```c++
 types.add_type<World>("World")
-  .constructor<const std::string&>(false);
+  .constructor<const std::string&>(jlcxx::finalize_policy::no);
 ```
 
 The `add_type` function actually builds two Julia types related to `World`.
@@ -648,10 +648,10 @@ The behavior of the macro can be customized by adding methods to `CxxWrap.refere
 ## Exceptions
 
 When directly adding a regular free C++ function as a method, it will be called directly using `ccall` and any exception will abort the Julia program.
-To avoid this, you can force wrapping it in an `std::function` to intercept the exception automatically by setting the `force_convert` argument to `method` to true:
+To avoid this, you can force wrapping it in an `std::function` to intercept the exception automatically by setting the `jlcxx::calling_policy` argument to `std_function`:
 
 ```c++
-mod.method("test_exception", test_exception, true);
+mod.method("test_exception", test_exception, jlcxx::calling_policy::std_function);
 ```
 
 Member functions and lambdas are automatically wrapped in an `std::function` and so any exceptions thrown there are always intercepted and converted to a Julia exception.

--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -304,6 +304,7 @@ mutable struct CppFunctionInfo
   function_pointer::Ptr{Cvoid}
   thunk_pointer::Ptr{Cvoid}
   override_module::Module
+  doc::Any
 end
 
 # Interpreted as a constructor for Julia  > 0.5
@@ -646,6 +647,12 @@ function build_function_expression(func::CppFunctionInfo, funcidx, julia_mod)
   end
 
   function_expression = :($(make_func_declaration((func.name,func.override_module), argmap(argtypes), julia_mod))::$(map_julia_return_type(func.julia_return_type)) = $call_exp)
+
+  if func.doc != ""
+    function_expression = :(Core.@doc $(func.doc) $function_expression)
+    println(function_expression)
+  end
+
   return function_expression
 end
 

--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -646,7 +646,7 @@ function build_function_expression(func::CppFunctionInfo, funcidx, julia_mod)
   # Build an array of arg1::Type1... expressions
   function argmap(signature)
     result = Expr[]
-    for (t, s, i) in zip(signature, argsymbols, range(1,length(signature)))
+    for (t, s, i) in zip(signature, argsymbols, 1:length(signature))
       argt = map_julia_arg_type_named(func.name, t)
       if isassigned(arg_default_values, i)
         # somewhat strange syntax to define default argument argument...

--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -652,7 +652,9 @@ function build_function_expression(func::CppFunctionInfo, funcidx, julia_mod)
         # somewhat strange syntax to define default argument argument...
         kw = Expr(:kw)
         push!(kw.args, :($s::$argt))
-        push!(kw.args, arg_default_values[i])
+        # convert to t to avoid problems on the calling site with mismatchin data types
+        # (e.g. f(x::Int64 = Int32(1)) = ...  is not callable without argument because f(Int32) does not exist
+        push!(kw.args, t(arg_default_values[i]))
         push!(result, kw)
       else
         push!(result, :($s::$argt))

--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -305,6 +305,9 @@ mutable struct CppFunctionInfo
   thunk_pointer::Ptr{Cvoid}
   override_module::Module
   doc::Any
+  argument_names::Array{Any,1}
+  argument_default_values::Array{Any,1}
+  n_keyword_arguments::Any
 end
 
 # Interpreted as a constructor for Julia  > 0.5
@@ -470,9 +473,9 @@ function process_fname(fn::CallOpOverload)
   return :(arg1::$(fn._type))
 end
 
-make_func_declaration(fn, argmap, julia_mod) = :($(process_fname(fn, julia_mod))($(argmap...)))
-function make_func_declaration(fn::Tuple{CallOpOverload,Module}, argmap, julia_mod)
-  return :($(process_fname(fn, julia_mod))($((argmap[2:end])...)))
+make_func_declaration(fn, argmap, kw_argmap, julia_mod) = :($(process_fname(fn, julia_mod))($(argmap...);$(kw_argmap...)))
+function make_func_declaration(fn::Tuple{CallOpOverload,Module}, argmap, kw_argmap, julia_mod)
+  return :($(process_fname(fn, julia_mod))($((argmap[2:end])...);$(kw_argmap...)))
 end
 
 # By default, no argument overloading happens
@@ -588,7 +591,9 @@ end
 function build_function_expression(func::CppFunctionInfo, funcidx, julia_mod)
   # Arguments and types
   argtypes = func.argument_types
-  argsymbols = map((i) -> Symbol(:arg,i[1]), enumerate(argtypes))
+  argnames = func.argument_names
+  argsymbols = map((i) -> i[1] <= length(argnames) ? Symbol(argnames[i[1]]) : Symbol(:arg,i[1]), enumerate(argtypes))
+  n_kw_args = func.n_keyword_arguments
 
   map_c_arg_type(t::Type) = map_c_arg_type(Base.invokelatest(cpp_trait_type, t), t)
   map_c_arg_type(::Type{IsNormalType}, t::Type) = t
@@ -646,11 +651,14 @@ function build_function_expression(func::CppFunctionInfo, funcidx, julia_mod)
     return result
   end
 
-  function_expression = :($(make_func_declaration((func.name,func.override_module), argmap(argtypes), julia_mod))::$(map_julia_return_type(func.julia_return_type)) = $call_exp)
+  complete_argmap = argmap(argtypes)
+  pos_argmap = complete_argmap[1:end-n_kw_args]
+  kw_argmap = complete_argmap[end-n_kw_args+1:end]
+
+  function_expression = :($(make_func_declaration((func.name,func.override_module), pos_argmap, kw_argmap, julia_mod))::$(map_julia_return_type(func.julia_return_type)) = $call_exp)
 
   if func.doc != ""
     function_expression = :(Core.@doc $(func.doc) $function_expression)
-    println(function_expression)
   end
 
   return function_expression

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -73,7 +73,7 @@ end
 
 # Test functions from the CppTestFunctions module
 @test CppTestFunctions.concatenate_numbers(4, 2.) == "42"
-@test methods(CppTestFunctions.concatenate_numbers_with_named_args)[1].slot_syms == "#self#\0i\0d\0val\0"
+@test startswith(methods(CppTestFunctions.concatenate_numbers_with_named_args)[1].slot_syms, "#self#\0i\0d\0")
 @test CppTestFunctions.concatenate_numbers_with_kwargs(d=2., i=4) == "42"
 @test CppTestFunctions.concatenate_numbers_with_default_values(3) == "35.2"
 @test CppTestFunctions.concatenate_numbers_with_default_values_of_different_type(3) == "35"

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -75,6 +75,7 @@ end
 @test CppTestFunctions.concatenate_numbers(4, 2.) == "42"
 @test methods(CppTestFunctions.concatenate_numbers_with_named_args)[1].slot_syms == "#self#\0i\0d\0val\0"
 @test CppTestFunctions.concatenate_numbers_with_kwargs(d=2., i=4) == "42"
+@test CppTestFunctions.concatenate_numbers_with_default_values(3) == "35.2"
 @test hasmethod(CppTestFunctions.concatenate_numbers, (Union{Cint,CxxWrap.CxxWrapCore.argument_overloads(Cint)...},Union{Cdouble,CxxWrap.CxxWrapCore.argument_overloads(Cdouble)...}))
 @test CppTestFunctions.concatenate_strings(2, "ho", "la") == "holahola"
 @test CppTestFunctions.test_int32_array(Int32[1,2])

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -76,6 +76,9 @@ end
 @test methods(CppTestFunctions.concatenate_numbers_with_named_args)[1].slot_syms == "#self#\0i\0d\0val\0"
 @test CppTestFunctions.concatenate_numbers_with_kwargs(d=2., i=4) == "42"
 @test CppTestFunctions.concatenate_numbers_with_default_values(3) == "35.2"
+@test CppTestFunctions.concatenate_numbers_with_default_values_of_different_type(3) == "35"
+@test CppTestFunctions.concatenate_numbers_with_default_kwarg(3) == "35.2"
+@test CppTestFunctions.concatenate_numbers_with_default_kwarg(3, d=7) == "37"
 @test hasmethod(CppTestFunctions.concatenate_numbers, (Union{Cint,CxxWrap.CxxWrapCore.argument_overloads(Cint)...},Union{Cdouble,CxxWrap.CxxWrapCore.argument_overloads(Cdouble)...}))
 @test CppTestFunctions.concatenate_strings(2, "ho", "la") == "holahola"
 @test CppTestFunctions.test_int32_array(Int32[1,2])

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -73,6 +73,8 @@ end
 
 # Test functions from the CppTestFunctions module
 @test CppTestFunctions.concatenate_numbers(4, 2.) == "42"
+@test methods(CppTestFunctions.concatenate_numbers_with_named_args)[1].slot_syms == "#self#\0i\0d\0val\0"
+@test CppTestFunctions.concatenate_numbers_with_kwargs(d=2., i=4) == "42"
 @test hasmethod(CppTestFunctions.concatenate_numbers, (Union{Cint,CxxWrap.CxxWrapCore.argument_overloads(Cint)...},Union{Cdouble,CxxWrap.CxxWrapCore.argument_overloads(Cdouble)...}))
 @test CppTestFunctions.concatenate_strings(2, "ho", "la") == "holahola"
 @test CppTestFunctions.test_int32_array(Int32[1,2])


### PR DESCRIPTION
Inspired by pybind11, this allows to write:
```c++
m.method("name", &function, jlcxx::arg("firstArg"), jlcxx::arg("secondArg")=7, jlcxx::kwarg("hello")=5, jlcxx::kwarg("there")=42);
```
Which translates roughly to:
```julia
name(firstArg::Type1, secondArg::Type2 = 7; hello::Type3, there::Type4 = 42)
```

Also supports docstrings (just a `const char*` argument) and additional arguments of some variants of method (calling convention) have extra enum types (to allow parsing arbitrary arguments).
Example:
```
  mod.method("test_exception", test_exception, jlcxx::calling_policy::std_function);
```