### PR TITLE
Remove overloading `promote_type`

### DIFF
--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -124,6 +124,15 @@ Base.Bool(x::T) where {T<:CxxNumber} = Bool(reinterpret(julia_int_type(T), x))::
 
 Base.flipsign(x::T, y::T) where {T <: CxxSigned} = reinterpret(T, flipsign(to_julia_int(x), to_julia_int(y)))
 
+for op in (:+, :-, :*, :&, :|, :xor)
+  @eval function Base.$op(a::S, b::S) where {S<:CxxNumber}
+    T = julia_int_type(S)
+    aT, bT = a % T, b % T
+    Base.not_sametype((a, b), (aT, bT))
+    return S($op(aT, bT))
+  end
+end
+
 # Trait type to indicate a type is a C++-wrapped type
 struct IsCxxType end
 struct IsNormalType end

--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -129,7 +129,7 @@ for op in (:+, :-, :*, :&, :|, :xor)
     T = julia_int_type(S)
     aT, bT = a % T, b % T
     Base.not_sametype((a, b), (aT, bT))
-    return S($op(aT, bT))
+    return $op(aT, bT)
   end
 end
 

--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -110,8 +110,7 @@ function Base.promote_rule(::Type{CT}, ::Type{JT}) where {CT <: CxxNumber, JT <:
   end
   return Base.promote_rule(julia_int_type(CT), JT)
 end
-Base.promote_type(::Type{T}, ::Type{T}) where {T<:CxxNumber} = julia_int_type(T)
-Base.promote_rule(::Type{T}, ::Type{T}) where {T<:CxxNumber} = Base.promote_type(T,T)
+Base.promote_rule(::Type{T}, ::Type{T}) where {T<:CxxNumber} = julia_int_type(T)
 Base.promote_rule(::Type{T1}, ::Type{T2}) where {T1<:CxxNumber, T2<:CxxNumber} = Base.promote_rule(julia_int_type(T1), julia_int_type(T2))
 Base.AbstractFloat(x::CxxNumber) = Base.AbstractFloat(to_julia_int(x))
 


### PR DESCRIPTION
Resolves https://github.com/JuliaInterop/CxxWrap.jl/issues/425 in the way that is outlined in the docstrings

```julia
help?> Base.promote_type
  promote_type(type1, type2, ...)

  Promotion refers to converting values of mixed types to a single common type.
  promote_type represents the default promotion behavior in Julia when operators (usually
  mathematical) are given arguments of differing types. promote_type generally tries to
  return a type which can at least approximate most values of either input type without
  excessively widening. Some loss is tolerated; for example, promote_type(Int64, Float64)
  returns Float64 even though strictly, not all Int64 values can be represented exactly as
  Float64 values.

  See also: promote, promote_typejoin, promote_rule.

  [...]

  │ Don't overload this directly
  │
  │  To overload promotion for your own types you should overload promote_rule.
  │  promote_type calls promote_rule internally to determine the type. Overloading
  │  promote_type directly can cause ambiguity errors.

help?> Base.promote_rule
  promote_rule(type1, type2)

  Specifies what type should be used by promote when given values of types type1 and type2.
  This function should not be called directly, but should have definitions added to it for
  new types as appropriate.
```