### PR TITLE
Add `StdStack` and fix `StdQueue` methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ libcxxwrap_julia_jll = "3eaa8342-bff7-56a5-9981-c04077f7cee7"
 [compat]
 MacroTools = "0.5.9"
 julia = "1.6"
-libcxxwrap_julia_jll = "0.13.0"
+libcxxwrap_julia_jll = "0.13.2"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -948,8 +948,8 @@ ConstCxxPtr, ConstCxxRef, CxxRef, CxxPtr,
 CppEnum, ConstArray, CxxBool, CxxLong, CxxULong, CxxChar, CxxChar16, CxxChar32, CxxWchar, CxxUChar, CxxSignedChar,
 CxxLongLong, CxxULongLong, ptrunion, gcprotect, gcunprotect, isnull
 
-using .StdLib: StdVector, StdString, StdWString, StdValArray, StdThread, StdDeque, StdQueue, StdSet, StdMultiset, StdUnorderedSet, StdUnorderedMultiset, StdPriorityQueue
+using .StdLib: StdVector, StdString, StdWString, StdValArray, StdThread, StdDeque, StdQueue, StdStack, StdSet, StdMultiset, StdUnorderedSet, StdUnorderedMultiset, StdPriorityQueue
 
-export StdLib, StdVector, StdString, StdWString, StdValArray, StdThread, StdDeque, StdQueue, StdSet, StdMultiset, StdUnorderedSet, StdUnorderedMultiset, StdPriorityQueue
+export StdLib, StdVector, StdString, StdWString, StdValArray, StdThread, StdDeque, StdQueue, StdStack, StdSet, StdMultiset, StdUnorderedSet, StdUnorderedMultiset, StdPriorityQueue
 
 end # module

--- a/src/StdLib.jl
+++ b/src/StdLib.jl
@@ -205,9 +205,11 @@ Base.popfirst!(v::StdDeque) = pop_front!(v)
 Base.resize!(v::StdDeque, n::Integer) = resize!(v, n)
 
 Base.size(v::StdQueue) = (Int(cppsize(v)),)
-Base.push!(v::StdQueue, x) = push_back!(v, x)
+Base.length(v::StdQueue) = Int(cppsize(v))
+Base.isempty(v::StdQueue) = q_empty(v)
+Base.push!(v::StdQueue, x) = (push_back!(v, x); v)
 Base.first(v::StdQueue) = front(v)
-Base.pop!(v::StdQueue) = pop_front!(v)
+Base.pop!(v::StdQueue) = (pop_front!(v); v)
 
 for StdSetType in (StdSet, StdUnorderedSet)
   Base.size(v::StdSetType) = (Int(cppsize(v)),)

--- a/src/StdLib.jl
+++ b/src/StdLib.jl
@@ -211,6 +211,13 @@ Base.push!(v::StdQueue, x) = (push_back!(v, x); v)
 Base.first(v::StdQueue) = front(v)
 Base.pop!(v::StdQueue) = (pop_front!(v); v)
 
+Base.size(v::StdStack) = (Int(cppsize(v)),)
+Base.length(v::StdStack) = Int(cppsize(v))
+Base.isempty(v::StdStack) = stack_isempty(v)
+Base.push!(v::StdStack, x) = (stack_push!(v, x); v)
+Base.first(v::StdStack) = stack_top(v)
+Base.pop!(v::StdStack) = (stack_pop!(v); v)
+
 for StdSetType in (StdSet, StdUnorderedSet)
   Base.size(v::StdSetType) = (Int(cppsize(v)),)
   Base.length(v::StdSetType) = Int(cppsize(v))

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -314,17 +314,34 @@ let
   @test length(deque2) == 1
 end
 
-let
-  @show "test queue"
-  queue = StdQueue{Int64}()
-  @test length(queue) == 0
-  push!(queue, 10)
-  push!(queue, 20)
-  @test length(queue) == 2
-  @test first(queue) == 10
-  pop!(queue)
-  @test first(queue) == 20
-  @test length(queue) == 1
+@testset "StdQueue" begin
+  @testset "Queue with integers" begin
+    queue = StdQueue{Int64}()
+    @test length(queue) == 0
+    @test isempty(queue) == true
+    push!(queue, 10)
+    queue = push!(queue, 20)
+    @test length(queue) == 2
+    @test first(queue) == 10
+    pop!(queue)
+    @test first(queue) == 20
+    @test length(queue) == 1
+    @test isempty(queue) == false  
+  end
+
+  @testset "Queue with floats" begin
+    queue = StdQueue{Float64}()
+    @test length(queue) == 0
+    @test isempty(queue) == true
+    push!(queue, 1.54)
+    push!(queue, 20.2)
+    @test length(queue) == 2
+    @test first(queue) == 1.54
+    queue = pop!(queue)
+    @test first(queue) == 20.2
+    @test length(queue) == 1
+    @test isempty(queue) == false  
+  end
 end
 
 @testset "StdPriorityQueue" begin

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -364,6 +364,40 @@ end
   @test_throws ArgumentError pop!(pq)
 end
 
+@testset "StdStack" begin
+  @testset "Stack with integers" begin
+    stack = StdStack{Int64}()
+    @test length(stack) == 0
+    @test isempty(stack) == true
+    push!(stack, 7)
+    stack = push!(stack, 20)
+    push!(stack, 2)
+    @test first(stack) == 2
+    @test length(stack) == 3
+    stack = pop!(stack)
+    @test first(stack) == 20
+    @test isempty(stack) == false
+    while !isempty(stack) 
+      pop!(stack)
+    end
+    @test isempty(stack) == true
+  end
+
+  @testset "Stack with floats" begin
+    stack = StdStack{Float64}()
+    @test length(stack) == 0
+    @test isempty(stack) == true
+    push!(stack, 1.54)
+    push!(stack, 20.2)
+    @test length(stack) == 2
+    @test first(stack) == 20.2
+    pop!(stack)
+    @test first(stack) == 1.54
+    @test length(stack) == 1
+    @test isempty(stack) == false  
+  end
+end
+
 @testset "StdSet and StdUnorderedSet" begin
   for StdSetType in (StdSet, StdUnorderedSet)
     @testset "Set with integers" begin


### PR DESCRIPTION
https://github.com/PraneethJain/libcxxwrap-julia#linear-containers

- The `push!` and `pop!` methods for `StdQueue` now return the container after mutating it. Added missing methods (`length` and `isempty`) for `StdQueue`. Improved the test set.
- Added `StdStack` support