### PR TITLE
refactor: iterators

### DIFF
--- a/README.md
+++ b/README.md
@@ -961,7 +961,7 @@ You  can also further specialize on `T` to get specific behavior depending on th
 | `StdForwardList`       | `std::forward_list`       | To be released  |
 |                        |                           |                 |
 
-View [StdLib](./src/StdLib) to check available methods.
+View [StdLib](./src/StdLib) to check available methods. The containers have iterators defined, and hence are iterable.
 
 To add support for e.g. vectors of your own type `World`, either just add methods that use an `std::vector<World>` as an argument, or manually wrap them using `jlcxx::stl::apply_stl<World>(mod);`.
 For this to work, add `#include "jlcxx/stl.hpp"` to your C++ file.

--- a/src/StdLib.jl
+++ b/src/StdLib.jl
@@ -25,6 +25,26 @@ function __init__()
   @initcxx
 end
 
+macro additerators(container_type, iterator_type)
+  quote
+    Base.:(==)(a::$(iterator_type), b::$(iterator_type)) = iterator_is_equal(a, b)
+    function _iteration_tuple(v::$(container_type), state::$(iterator_type))
+      (state == iteratorend(v)) ? nothing : (iterator_value(state), state)
+    end
+    Base.iterate(v::$(container_type)) = _iteration_tuple(v, iteratorbegin(v))
+    Base.iterate(v::$(container_type), state::$(iterator_type)) =
+      (state != iteratorend(v)) ? _iteration_tuple(v, iterator_next(state)) : nothing
+  end
+end
+
+@additerators StdDeque StdDequeIterator
+@additerators StdForwardList StdForwardListIterator
+@additerators StdList StdListIterator
+@additerators StdMultiset StdMultisetIterator
+@additerators StdUnorderedMultiset StdUnorderedMultisetIterator
+@additerators StdSet StdSetIterator
+@additerators StdUnorderedSet StdUnorderedSetIterator
+
 include("StdLib/StdDeque.jl")
 include("StdLib/StdForwardList.jl")
 include("StdLib/StdList.jl")

--- a/src/StdLib/StdDeque.jl
+++ b/src/StdLib/StdDeque.jl
@@ -9,9 +9,3 @@ Base.push!(v::StdDeque, x) = (isempty(v) ? push_front!(v, x) : push_back!(v, x);
 Base.pop!(v::StdDeque) = pop_back!(v)
 Base.popfirst!(v::StdDeque) = pop_front!(v)
 Base.resize!(v::StdDeque, n::Integer) = resize!(v, n)
-
-Base.:(==)(a::StdDequeIterator, b::StdDequeIterator) = iterator_is_equal(a, b)
-
-_deque_iteration_tuple(v::StdDeque, state::StdDequeIterator) = state == iteratorend(v) ? nothing : (iterator_value(state), state)
-Base.iterate(v::StdDeque) = _deque_iteration_tuple(v, iteratorbegin(v))
-Base.iterate(v::StdDeque, state::StdDequeIterator) = (state != iteratorend(v)) ? _deque_iteration_tuple(v, iterator_next(state)) : nothing

--- a/src/StdLib/StdForwardList.jl
+++ b/src/StdLib/StdForwardList.jl
@@ -6,11 +6,6 @@ Base.empty!(v::StdForwardList) = (flist_empty!(v); v)
 Base.pushfirst!(v::StdForwardList, x) = (flist_push_front!(v, x); v)
 Base.popfirst!(v::StdForwardList) = (flist_pop_front!(v); v)
 
-Base.:(==)(a::StdForwardListIterator, b::StdForwardListIterator) = iterator_is_equal(a, b)
-_forward_list_iteration_tuple(v::StdForwardList, state::StdForwardListIterator) = (state == iteratorend(v)) ? nothing : (iterator_value(state), state)
-Base.iterate(v::StdForwardList) = _forward_list_iteration_tuple(v, iteratorbegin(v))
-Base.iterate(v::StdForwardList, state::StdForwardListIterator) = (state != iteratorend(v)) ? _forward_list_iteration_tuple(v, iterator_next(state)) : nothing
-
 function Base.show(io::IO, ::MIME"text/plain", container::StdForwardList{T}) where {T}
     print(io, "StdForwardList{", T, "}")
 

--- a/src/StdLib/StdList.jl
+++ b/src/StdLib/StdList.jl
@@ -12,11 +12,6 @@ Base.pop!(v::StdList) = (list_pop_back!(v); v)
 Base.popfirst!(v::StdList) = (list_pop_front!(v); v)
 Base.sort!(v::StdList) = (StdListSort(v); v)
 
-Base.:(==)(a::StdListIterator, b::StdListIterator) = iterator_is_equal(a, b)
-_list_iteration_tuple(v::StdList, state::StdListIterator) = (state == iteratorend(v)) ? nothing : (iterator_value(state), state)
-Base.iterate(v::StdList) = _list_iteration_tuple(v, iteratorbegin(v))
-Base.iterate(v::StdList, state::StdListIterator) = (state != iteratorend(v)) ? _list_iteration_tuple(v, iterator_next(state)) : nothing
-
 function Base.show(io::IO, ::MIME"text/plain", container::StdList{T}) where {T}
     n = length(container)
     print(io, "StdList{", T, "} with ", n, " element", n == 1 ? "" : "s")

--- a/src/StdLib/StdMultisetTypes.jl
+++ b/src/StdLib/StdMultisetTypes.jl
@@ -10,13 +10,3 @@ for StdMultisetType in (StdMultiset, StdUnorderedMultiset)
     Base.delete!(v::StdMultisetType, x) = (multiset_delete!(v, x); v)
     Base.count(x, v::StdMultisetType) = multiset_count(v, x)
 end
-
-Base.:(==)(a::StdMultisetIterator, b::StdMultisetIterator) = iterator_is_equal(a, b)
-_multiset_iteration_tuple(v::StdMultiset, state::StdMultisetIterator) = (state == iteratorend(v)) ? nothing : (iterator_value(state), state)
-Base.iterate(v::StdMultiset) = _multiset_iteration_tuple(v, iteratorbegin(v))
-Base.iterate(v::StdMultiset, state::StdMultisetIterator) = (state != iteratorend(v)) ? _multiset_iteration_tuple(v, iterator_next(state)) : nothing
-
-Base.:(==)(a::StdUnorderedMultisetIterator, b::StdUnorderedMultisetIterator) = iterator_is_equal(a, b)
-_unordered_multiset_iteration_tuple(v::StdUnorderedMultiset, state::StdUnorderedMultisetIterator) = (state == iteratorend(v)) ? nothing : (iterator_value(state), state)
-Base.iterate(v::StdUnorderedMultiset) = _unordered_multiset_iteration_tuple(v, iteratorbegin(v))
-Base.iterate(v::StdUnorderedMultiset, state::StdUnorderedMultisetIterator) = (state != iteratorend(v)) ? _unordered_multiset_iteration_tuple(v, iterator_next(state)) : nothing

--- a/src/StdLib/StdSetTypes.jl
+++ b/src/StdLib/StdSetTypes.jl
@@ -9,13 +9,3 @@ for StdSetType in (StdSet, StdUnorderedSet)
     Base.in(x, v::StdSetType) = set_in(v, x)
     Base.delete!(v::StdSetType, x) = (set_delete!(v, x); v)
 end
-
-Base.:(==)(a::StdSetIterator, b::StdSetIterator) = iterator_is_equal(a, b)
-_set_iteration_tuple(v::StdSet, state::StdSetIterator) = (state == iteratorend(v)) ? nothing : (iterator_value(state), state)
-Base.iterate(v::StdSet) = _set_iteration_tuple(v, iteratorbegin(v))
-Base.iterate(v::StdSet, state::StdSetIterator) = (state != iteratorend(v)) ? _set_iteration_tuple(v, iterator_next(state)) : nothing
-
-Base.:(==)(a::StdUnorderedSetIterator, b::StdUnorderedSetIterator) = iterator_is_equal(a, b)
-_unordered_set_iteration_tuple(v::StdUnorderedSet, state::StdUnorderedSetIterator) = (state == iteratorend(v)) ? nothing : (iterator_value(state), state)
-Base.iterate(v::StdUnorderedSet) = _unordered_set_iteration_tuple(v, iteratorbegin(v))
-Base.iterate(v::StdUnorderedSet, state::StdUnorderedSetIterator) = (state != iteratorend(v)) ? _unordered_set_iteration_tuple(v, iterator_next(state)) : nothing


### PR DESCRIPTION
https://github.com/JuliaInterop/libcxxwrap-julia#main
- Added a macro to add iterators given a container type and its iterator type
- Mentioned that the STL containers are iterable in the readme.