### PR TITLE
use invokelatest to access bindings generated with Core.eval

### DIFF
--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -766,17 +766,19 @@ end
 
 # Wrap functions from the cpp module to the passed julia module
 function wrap_functions(functions, julia_mod)
-  if !isempty(julia_mod.__cxxwrap_pointers)
-    empty!(julia_mod.__cxxwrap_methodkeys)
-    empty!(julia_mod.__cxxwrap_pointers)
+  cxxp = Base.invokelatest(getproperty, julia_mod, :__cxxwrap_pointers)
+  cxxmk = Base.invokelatest(getproperty, julia_mod, :__cxxwrap_methodkeys)
+  if !isempty(cxxp)
+    empty!(cxxmk)
+    empty!(cxxp)
   end
   precompiling = true
 
   for func in functions
     (mkey,fptrs) = _register_function_pointers(func, precompiling)
-    push!(julia_mod.__cxxwrap_methodkeys, mkey)
-    push!(julia_mod.__cxxwrap_pointers, fptrs)
-    funcidx = length(julia_mod.__cxxwrap_pointers)
+    push!(cxxmk, mkey)
+    push!(cxxp, fptrs)
+    funcidx = length(cxxp)
 
     Core.eval(julia_mod, build_function_expression(func, funcidx, julia_mod))
   end


### PR DESCRIPTION
To fix these warnings (future errors) during precompilation on julia nightly:
```
┌ CxxWrap
│  WARNING: Detected access to binding `StdLib.__cxxwrap_pointers` in a world prior to its definition world.
│    Julia 1.12 has introduced more strict world age semantics for global bindings.
│    !!! This code may malfunction under Revise.
│    !!! This code will error in future versions of Julia.
│  Hint: Add an appropriate `invokelatest` around the access to this binding.
│  WARNING: Detected access to binding `StdLib.__cxxwrap_methodkeys` in a world prior to its definition world.
│    Julia 1.12 has introduced more strict world age semantics for global bindings.
│    !!! This code may malfunction under Revise.
│    !!! This code will error in future versions of Julia.
│  Hint: Add an appropriate `invokelatest` around the access to this binding.
└  
```
cc: @fingolfin 

Depending on the timeline for 0.17 it might be good to have this in a 0.16.1 release as well.