### PR TITLE
Allow passing a Vector of strings to jlcxx::ArrayRef

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CxxWrap"
 uuid = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 authors = ["Bart Janssens <bart@bartjanssens.org>"]
-version = "0.17.0"
+version = "0.17.1"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/README.md
+++ b/README.md
@@ -1070,6 +1070,9 @@ Often, new releases of `CxxWrap` also require a new release of the C++ component
 There was no change in the API, but because of a change in the way the mapping between C++ and Julia types is implemented the C++ modules need to be recompiled against `libcxxwrap-julia` 0.13.
 The reason for this change is that the old method caused crahses on macOS with Apple CPUs (M1, ...).
 
+## Breaking changes in v0.17
+
+* The binary parts of dependent packages need to be rebuilt against `libcxxwrap-julia` 0.14, which has a better way of adding STL functionality
 
 ## References
 * [JuliaCon 2020 Talk: Julia and C++: a technical overview of CxxWrap.jl](https://www.youtube.com/watch?v=u7IaXwKSUU0)

--- a/src/CxxWrap.jl
+++ b/src/CxxWrap.jl
@@ -590,6 +590,7 @@ map_julia_arg_type(t::Type{CxxPtr{T}}, ::Type{IsCxxType}) where {T} = Union{CxxP
 map_julia_arg_type(t::Type{CxxPtr{CxxChar}}) = Union{PtrTypes{Cchar}, String}
 map_julia_arg_type(t::Type{<:Array{T}}) where {T <: CxxNumber} = Union{t, Array{julia_int_type(T)}}
 map_julia_arg_type(t::Type{<:Array{Ptr{T}}}) where {T <: CxxNumber} = Union{t, Array{Ptr{julia_int_type(T)}}}
+map_julia_arg_type(t::Type{Vector{Ptr{CxxChar}}}) = Union{t, Vector{Ptr{julia_int_type(CxxChar)}}, Vector{String}}
 map_julia_arg_type(t::Type{ConstCxxPtr{CxxChar}}) = Union{ConstPtrTypes{Cchar}, String}
 map_julia_arg_type(::Type{T}) where {T<:Tuple} = Tuple{map_julia_arg_type.(T.parameters)...}
 
@@ -616,8 +617,10 @@ Base.unsafe_convert(to_type::Type{<:CxxBaseRef{T}}, v::CxxBaseRef) where {T} = t
 Base.unsafe_convert(to_type::Type{<:CxxBaseRef}, v::Base.RefValue) = to_type(pointer_from_objref(v))
 
 Base.cconvert(::Type{CxxPtr{CxxPtr{CxxChar}}}, v::Vector{String}) = Base.cconvert(Ptr{Ptr{Cchar}}, v)
+Base.cconvert(::Type{Vector{Ptr{CxxChar}}}, v::Vector{String}) = Base.cconvert(Ptr{Ptr{Cchar}}, v)
 Base.unsafe_convert(to_type::Type{CxxPtr{CxxPtr{CxxChar}}}, a::Base.RefArray{Ptr{Cchar}, Vector{Ptr{Cchar}}, Any}) = to_type(Base.unsafe_convert(Ptr{Ptr{Cchar}}, a))
 Base.unsafe_convert(to_type::Type{CxxPtr{CxxPtr{CxxChar}}}, a::Base.RefArray{Ptr{Cchar}, Vector{Ptr{Cchar}}, Vector{Any}}) = to_type(Base.unsafe_convert(Ptr{Ptr{Cchar}}, a))
+Base.unsafe_convert(::Type{Vector{Ptr{CxxChar}}}, a::Union{Base.RefArray{Ptr{Cchar}, Vector{Ptr{Cchar}}, Any}, Base.RefArray{Ptr{Cchar}, Vector{Ptr{Cchar}}, Vector{Any}}}) = a.x[1:end-1]
 
 cxxconvert(to_type::Type{<:CxxBaseRef{T}}, x, ::Type{IsNormalType}) where {T} = Ref{T}(convert(T,x))
 cxxconvert(to_type::Type{<:CxxBaseRef{T}}, x::Base.RefValue, ::Type{IsNormalType}) where {T} = x

--- a/test/containers.jl
+++ b/test/containers.jl
@@ -70,5 +70,6 @@ let artup = ([1.0,1.0,1.0], [3.0,3.0])
 end
 
 @test Containers.make_tuple_vector() == [(1.0,2.0), (3.0,4.0)]
+@test Containers.catstrings(["aaa", "bb"]) == "aaabb"
 
 end


### PR DESCRIPTION
https://github.com/JuliaInterop/libcxxwrap-julia#catstrings

For issue https://github.com/JuliaInterop/libcxxwrap-julia/issues/188