### PR TITLE
Add `LazyLibrary` support

### DIFF
--- a/test/except.jl
+++ b/test/except.jl
@@ -1,6 +1,10 @@
 include(joinpath(@__DIR__, "testcommon.jl"))
 
-const libexcept = CxxWrap.CxxWrapCore.libexcept()
+@static if VERSION ≥ v"1.12"
+  using CxxWrap.CxxWrapCore: libexcept
+else
+  const libexcept = CxxWrap.CxxWrapCore.libexcept()
+end
 
 @testset "$(basename(@__FILE__)[1:end-3])" begin
 

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -243,7 +243,11 @@ end
 half_julia(d::Float64) = d*0.5
 
 # C version
-half_c(d::Float64) = ccall((:half_c, CxxWrap.CxxWrapCore.libfunctions()), Cdouble, (Cdouble,), d)
+@static if VERSION ≥ v"1.12"
+  half_c(d::Float64) = ccall((:half_c, CxxWrap.CxxWrapCore.libfunctions), Cdouble, (Cdouble,), d)
+else
+  half_c(d::Float64) = ccall((:half_c, CxxWrap.CxxWrapCore.libfunctions()), Cdouble, (Cdouble,), d)
+end
 
 # Bring C++ versions into scope
 using .CppHalfFunctions: half_d, half_lambda, half_loop_cpp!, half_loop_jlcall!, half_loop_cfunc!


### PR DESCRIPTION
On Julia 1.13+ (nightly), `ccall((:fn, library()), ...)` gives `TypeError: in ccall library name, expected Symbol, got a value of type Expr` making this a required transition (see https://github.com/JuliaLang/julia/pull/59165)

This should be an improvement over the pattern in https://github.com/JuliaInterop/CxxWrap.jl/pull/494:
```julia
const libfunctions = CxxWrap.CxxWrapCore.libfunctions()
```

which if followed by users would cause issues like https://github.com/JuliaInterop/CxxWrap.jl/issues/230 since the library paths would be computed too eagerly.

Instead, users on 1.12+ should use these like normal JLL / library globals:
```julia
# old: ccall((:half_c, CxxWrap.CxxWrapCore.libfunctions()), ...)
ccall((:half_c, CxxWrap.CxxWrapCore.libfunctions), ...)
```
`@wrapmodule` / `@readmodule` continue to work as before.