### PR TITLE
Update dependency libcxxwrap_julia_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CxxWrap"
 uuid = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 authors = ["Bart Janssens <bart@bartjanssens.org>"]
-version = "0.17.3"
+version = "0.17.4"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -11,7 +11,7 @@ libcxxwrap_julia_jll = "3eaa8342-bff7-56a5-9981-c04077f7cee7"
 [compat]
 MacroTools = "0.5.9"
 julia = "1.6"
-libcxxwrap_julia_jll = "0.14.4"
+libcxxwrap_julia_jll = "0.14.5"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"


### PR DESCRIPTION
Following https://github.com/JuliaInterop/libcxxwrap-julia/issues/192, we need to bump the `libcxxwrap_julia_jll` version to `0.14.5`. AFAIK this does not require any changes on the CxxWrap side.